### PR TITLE
Don't set -D warnings in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ env:
   CARGO_NET_RETRY: 10
   CI: 1
   RUST_BACKTRACE: short
-  RUSTFLAGS: "-D warnings -W rust-2021-compatibility"
+  RUSTFLAGS: "-W rust-2021-compatibility"
   RUSTUP_MAX_RETRIES: 10
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ flags the function for cargo-mutants.
 * Trees that `deny` style lints such as unused parameters are likely to fail to
   build when mutated, without really saying much about the value of the tests.
   I suggest you don't statically deny warnings in your source code, but rather
-  set `RUSTFLAGS` when you do want to check this.
+  set `RUSTFLAGS` when you do want to check this -- and don't do this when
+  running `cargo mutants`.
 
 * Anything you can do to make the `cargo build` and `cargo test` suite faster
   will have a multiplicative effect on `cargo mutants` run time, and of course


### PR DESCRIPTION
This makes most mutants check-failed.