### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -3,6 +3,8 @@ permissions:
 
 on:
   push:
+    branches:
+      - main
     paths:
       - ".github/workflows/install.yml"
   schedule:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -14,6 +14,7 @@ jobs:
   cargo-install:
     runs-on: ubuntu-latest
     steps:
+      - uses: Swatinem/rust-cache@v2
       - name: cargo-install
         run: |
           cargo install cargo-mutants

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -28,7 +28,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         name: Install older toolchain
         with:

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -5,8 +5,9 @@ permissions:
 
 on:
   push:
+    branches:
+      - main
   pull_request:
-    branch: main
 
 # see https://matklad.github.io/2021/09/04/fast-rust-builds.html
 env:

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -29,6 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: Swatinem/rust-cache@v2
       - uses: actions-rs/toolchain@v1
         name: Install older toolchain
         with:
@@ -38,13 +39,5 @@ jobs:
         run: |
           cargo --version
           rustc --version
-      - name: Cache Cargo
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-${{ matrix.toolchain }}-${{ hashFiles('Cargo.lock') }}
       - name: Test
         run: cargo test --workspace

--- a/.github/workflows/mutate-self.yaml
+++ b/.github/workflows/mutate-self.yaml
@@ -14,7 +14,7 @@ jobs:
   cargo-mutants:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Cache Cargo
         uses: actions/cache@v2
         with:

--- a/.github/workflows/mutate-self.yaml
+++ b/.github/workflows/mutate-self.yaml
@@ -15,15 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Cache Cargo
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key:
-            cargo-mutants-self-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v2
       - name: Install
         run: |
           cargo install --path .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Show Cargo and rustc version
         run: |
           cargo --version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,8 @@ permissions:
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 # see https://matklad.github.io/2021/09/04/fast-rust-builds.html

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,17 +34,7 @@ jobs:
         run: |
           cargo --version
           rustc --version
-      - name: Cache Cargo
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
-      # Don't enforce Clippy, because it can too easily flake when new lints are added.
-      # - name: Clippy
-      #   run: cargo clippy -- -D clippy::all
+      - uses: Swatinem/rust-cache@v2
       - name: rustfmt
         run: cargo fmt --all -- --check
       - name: Build


### PR DESCRIPTION
- [x] Run some tests only on PRs and pushes to main, not on every branch commit: should reduce redundant builds of both the branch and its merge
- [x] Update to actions/v3
- [x] Use https://github.com/marketplace/actions/rust-cache