### PR TITLE
Remove MutationOp

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # cargo-mutants changelog
 
+## Unreleased
+
+- Mutate functions returning `String` to `String::new()` rather than `"".into()`: same
+  result but a bit more idiomatic.
+
 - New `--leak-dirs` option, for debugging cargo-mutants.
 
 ## 1.2.2
@@ -29,9 +34,9 @@ Released 2023-01-05
 
 - Converted most of the docs to a book available at <https://mutants.rs/>.
 
-- Fixed: Correctly find submodules that don't use mmod.rs` naming, e.g. when
-descending from `src/foo.rs` to `src/foo/bar.rs`. Also handle module names that
-are raw identifiers using `r#`. (Thanks to @kpreid for the report.)
+- Fixed: Correctly find submodules that don't use mmod.rs`naming, e.g. when
+descending from`src/foo.rs`to`src/foo/bar.rs`. Also handle module names that
+are raw identifiers using`r#`. (Thanks to @kpreid for the report.)
 
 ## 1.2.0
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ use crate::console::Console;
 use crate::interrupt::check_interrupted;
 use crate::log_file::{last_line, LogFile};
 use crate::manifest::fix_manifest;
-use crate::mutate::{Mutant, MutationOp};
+use crate::mutate::Mutant;
 use crate::options::Options;
 use crate::outcome::{Phase, ScenarioOutcome};
 use crate::path::Utf8PathSlashes;

--- a/src/mutate.rs
+++ b/src/mutate.rs
@@ -64,35 +64,19 @@ pub struct Mutant {
     pub source_file: Arc<SourceFile>,
 
     /// The function that's being mutated.
-    function_name: Arc<String>,
+    pub function_name: Arc<String>,
 
     /// The return type of the function, as a fragment of Rust syntax.
-    return_type: Arc<String>,
+    pub return_type: Arc<String>,
 
     /// The mutated textual region.
-    span: Span,
+    pub span: Span,
 
     /// The type of change to apply.
     pub op: MutationOp,
 }
 
 impl Mutant {
-    pub fn new(
-        source_file: &Arc<SourceFile>,
-        op: MutationOp,
-        function_name: &Arc<String>,
-        return_type: &Arc<String>,
-        span: Span,
-    ) -> Mutant {
-        Mutant {
-            source_file: Arc::clone(source_file),
-            op,
-            function_name: Arc::clone(function_name),
-            return_type: Arc::clone(return_type),
-            span,
-        }
-    }
-
     /// Return text of the whole file with the mutation applied.
     pub fn mutated_code(&self) -> String {
         replace_region(

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -8,6 +8,7 @@
 //! e.g. for cargo they are identified from the targets. The tree walker then
 //! follows `mod` statements to recursively visit other referenced files.
 
+use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::sync::Arc;
 
@@ -125,13 +126,13 @@ impl DiscoveryVisitor {
     fn collect_fn_mutants(&mut self, return_type: &syn::ReturnType, span: &proc_macro2::Span) {
         let full_function_name = Arc::new(self.namespace_stack.join("::"));
         let return_type_str = Arc::new(return_type_to_string(return_type));
-        let mut new_mutants = ops_for_return_type(&return_type)
+        let mut new_mutants = return_value_replacements(return_type)
             .into_iter()
-            .map(|op| Mutant {
+            .map(|replacement| Mutant {
                 source_file: Arc::clone(&self.source_file),
-                op,
                 function_name: Arc::clone(&full_function_name),
                 return_type: Arc::clone(&return_type_str),
+                replacement,
                 span: span.into(),
             })
             .collect_vec();
@@ -296,10 +297,10 @@ impl<'ast> Visit<'ast> for DiscoveryVisitor {
     }
 }
 
-fn ops_for_return_type(return_type: &syn::ReturnType) -> Vec<MutationOp> {
-    let mut ops: Vec<MutationOp> = Vec::new();
+fn return_value_replacements(return_type: &syn::ReturnType) -> Vec<Cow<'static, str>> {
+    let mut reps: Vec<Cow<'static, str>> = Vec::new();
     match return_type {
-        syn::ReturnType::Default => ops.push(MutationOp::Unit),
+        syn::ReturnType::Default => reps.push(Cow::Borrowed("()")),
         syn::ReturnType::Type(_rarrow, box_typ) => match &**box_typ {
             syn::Type::Never(_) => {
                 // In theory we could mutate this to a function that just
@@ -309,18 +310,18 @@ fn ops_for_return_type(return_type: &syn::ReturnType) -> Vec<MutationOp> {
             syn::Type::Path(syn::TypePath { path, .. }) => {
                 // dbg!(&path);
                 if path.is_ident("bool") {
-                    ops.push(MutationOp::True);
-                    ops.push(MutationOp::False);
+                    reps.push("true".into());
+                    reps.push("false".into());
                 } else if path.is_ident("String") {
                     // TODO: Detect &str etc.
-                    ops.push(MutationOp::EmptyString);
-                    ops.push(MutationOp::Xyzzy);
+                    reps.push(r#""".into()"#.into());
+                    reps.push(r#""xyzzy".into()"#.into());
                 } else if path_is_result(path) {
                     // TODO: Try this for any path ending in "Result".
                     // TODO: Recursively generate for types inside the Ok side of the Result.
-                    ops.push(MutationOp::OkDefault);
+                    reps.push("Ok(Default::default())".into());
                 } else {
-                    ops.push(MutationOp::Default)
+                    reps.push("Default::default()".into());
                 }
             }
             syn::Type::Reference(syn::TypeReference {
@@ -332,11 +333,11 @@ fn ops_for_return_type(return_type: &syn::ReturnType) -> Vec<MutationOp> {
             }
             _ => {
                 trace!(?box_typ, "Return type is not recognized, trying Default");
-                ops.push(MutationOp::Default)
+                reps.push("Default::default()".into());
             }
         },
     }
-    ops
+    reps
 }
 
 fn type_name_string(ty: &syn::Type) -> String {

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -125,16 +125,14 @@ impl DiscoveryVisitor {
     fn collect_fn_mutants(&mut self, return_type: &syn::ReturnType, span: &proc_macro2::Span) {
         let full_function_name = Arc::new(self.namespace_stack.join("::"));
         let return_type_str = Arc::new(return_type_to_string(return_type));
-        let mut new_mutants = ops_for_return_type(return_type)
+        let mut new_mutants = ops_for_return_type(&return_type)
             .into_iter()
-            .map(|op| {
-                Mutant::new(
-                    &self.source_file,
-                    op,
-                    &full_function_name,
-                    &return_type_str,
-                    span.into(),
-                )
+            .map(|op| Mutant {
+                source_file: Arc::clone(&self.source_file),
+                op,
+                function_name: Arc::clone(&full_function_name),
+                return_type: Arc::clone(&return_type_str),
+                span: span.into(),
             })
             .collect_vec();
         if new_mutants.is_empty() {

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -314,7 +314,7 @@ fn return_value_replacements(return_type: &syn::ReturnType) -> Vec<Cow<'static, 
                     reps.push("false".into());
                 } else if path.is_ident("String") {
                     // TODO: Detect &str etc.
-                    reps.push(r#""".into()"#.into());
+                    reps.push(r#"String::new()"#.into());
                     reps.push(r#""xyzzy".into()"#.into());
                 } else if path_is_result(path) {
                     // TODO: Try this for any path ending in "Result".

--- a/tests/cli/snapshots/cli__list_mutants_in_all_trees_as_json.snap
+++ b/tests/cli/snapshots/cli__list_mutants_in_all_trees_as_json.snap
@@ -198,7 +198,7 @@ expression: buf
     "line": 1,
     "function": "say_hello",
     "return_type": "-> String",
-    "replacement": "\"\".into()"
+    "replacement": "String::new()"
   },
   {
     "package": "cargo-mutants-testdata-insta",
@@ -392,7 +392,7 @@ expression: buf
     "line": 5,
     "function": "try_value_coercion",
     "return_type": "-> String",
-    "replacement": "\"\".into()"
+    "replacement": "String::new()"
   },
   {
     "package": "mutants-testdata-typecheck-fails",
@@ -548,7 +548,7 @@ expression: buf
     "line": 26,
     "function": "double_string",
     "return_type": "-> String",
-    "replacement": "\"\".into()"
+    "replacement": "String::new()"
   },
   {
     "package": "cargo-mutants-testdata-well-tested",

--- a/tests/cli/snapshots/cli__list_mutants_in_all_trees_as_text.snap
+++ b/tests/cli/snapshots/cli__list_mutants_in_all_trees_as_text.snap
@@ -78,7 +78,7 @@ src/lib.rs:25: replace controlled_loop -> usize with Default::default()
 ## testdata/tree/insta
 
 ```
-src/lib.rs:1: replace say_hello -> String with "".into()
+src/lib.rs:1: replace say_hello -> String with String::new()
 src/lib.rs:1: replace say_hello -> String with "xyzzy".into()
 ```
 
@@ -152,7 +152,7 @@ src/lib.rs:11: replace make_an_s -> S with Default::default()
 ## testdata/tree/typecheck_fails
 
 ```
-src/lib.rs:5: replace try_value_coercion -> String with "".into()
+src/lib.rs:5: replace try_value_coercion -> String with String::new()
 src/lib.rs:5: replace try_value_coercion -> String with "xyzzy".into()
 ```
 
@@ -184,7 +184,7 @@ src/simple_fns.rs:7: replace returns_unit with ()
 src/simple_fns.rs:12: replace returns_42u32 -> u32 with Default::default()
 src/simple_fns.rs:17: replace divisible_by_three -> bool with true
 src/simple_fns.rs:17: replace divisible_by_three -> bool with false
-src/simple_fns.rs:26: replace double_string -> String with "".into()
+src/simple_fns.rs:26: replace double_string -> String with String::new()
 src/simple_fns.rs:26: replace double_string -> String with "xyzzy".into()
 src/struct_with_lifetime.rs:14: replace Lex<'buf>::buf_len -> usize with Default::default()
 ```

--- a/tests/cli/snapshots/cli__list_mutants_json_well_tested.snap
+++ b/tests/cli/snapshots/cli__list_mutants_json_well_tested.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/cli.rs
+source: tests/cli/main.rs
 expression: "String::from_utf8_lossy(&output.stdout)"
 ---
 [
@@ -105,7 +105,7 @@ expression: "String::from_utf8_lossy(&output.stdout)"
     "line": 26,
     "function": "double_string",
     "return_type": "-> String",
-    "replacement": "\"\".into()"
+    "replacement": "String::new()"
   },
   {
     "package": "cargo-mutants-testdata-well-tested",

--- a/tests/cli/snapshots/cli__list_mutants_well_tested.snap
+++ b/tests/cli/snapshots/cli__list_mutants_well_tested.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/cli.rs
+source: tests/cli/main.rs
 expression: "String::from_utf8_lossy(&output.stdout)"
 ---
 src/inside_mod.rs:3: replace outer::inner::name -> &'static str with Default::default()
@@ -14,7 +14,7 @@ src/simple_fns.rs:7: replace returns_unit with ()
 src/simple_fns.rs:12: replace returns_42u32 -> u32 with Default::default()
 src/simple_fns.rs:17: replace divisible_by_three -> bool with true
 src/simple_fns.rs:17: replace divisible_by_three -> bool with false
-src/simple_fns.rs:26: replace double_string -> String with "".into()
+src/simple_fns.rs:26: replace double_string -> String with String::new()
 src/simple_fns.rs:26: replace double_string -> String with "xyzzy".into()
 src/struct_with_lifetime.rs:14: replace Lex<'buf>::buf_len -> usize with Default::default()
 

--- a/tests/cli/snapshots/cli__well_tested_tree_check_only.snap
+++ b/tests/cli/snapshots/cli__well_tested_tree_check_only.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/cli.rs
+source: tests/cli/main.rs
 expression: stdout
 ---
 Found 15 mutants to test
@@ -16,7 +16,7 @@ src/simple_fns.rs:7: replace returns_unit with () ... ok
 src/simple_fns.rs:12: replace returns_42u32 -> u32 with Default::default() ... ok
 src/simple_fns.rs:17: replace divisible_by_three -> bool with true ... ok
 src/simple_fns.rs:17: replace divisible_by_three -> bool with false ... ok
-src/simple_fns.rs:26: replace double_string -> String with "".into() ... ok
+src/simple_fns.rs:26: replace double_string -> String with String::new() ... ok
 src/simple_fns.rs:26: replace double_string -> String with "xyzzy".into() ... ok
 src/struct_with_lifetime.rs:14: replace Lex<'buf>::buf_len -> usize with Default::default() ... ok
 15 mutants tested: 15 succeeded

--- a/tests/cli/snapshots/cli__well_tested_tree_finds_no_problems.snap
+++ b/tests/cli/snapshots/cli__well_tested_tree_finds_no_problems.snap
@@ -1,5 +1,5 @@
 ---
-source: tests/cli.rs
+source: tests/cli/main.rs
 expression: stdout
 ---
 Found 15 mutants to test
@@ -16,7 +16,7 @@ src/simple_fns.rs:7: replace returns_unit with () ... caught
 src/simple_fns.rs:12: replace returns_42u32 -> u32 with Default::default() ... caught
 src/simple_fns.rs:17: replace divisible_by_three -> bool with true ... caught
 src/simple_fns.rs:17: replace divisible_by_three -> bool with false ... caught
-src/simple_fns.rs:26: replace double_string -> String with "".into() ... caught
+src/simple_fns.rs:26: replace double_string -> String with String::new() ... caught
 src/simple_fns.rs:26: replace double_string -> String with "xyzzy".into() ... caught
 src/struct_with_lifetime.rs:14: replace Lex<'buf>::buf_len -> usize with Default::default() ... caught
 15 mutants tested: 15 caught

--- a/tests/cli/snapshots/cli__well_tested_tree_finds_no_problems__caught.txt.snap
+++ b/tests/cli/snapshots/cli__well_tested_tree_finds_no_problems__caught.txt.snap
@@ -14,7 +14,7 @@ src/simple_fns.rs:7: replace returns_unit with ()
 src/simple_fns.rs:12: replace returns_42u32 -> u32 with Default::default()
 src/simple_fns.rs:17: replace divisible_by_three -> bool with true
 src/simple_fns.rs:17: replace divisible_by_three -> bool with false
-src/simple_fns.rs:26: replace double_string -> String with "".into()
+src/simple_fns.rs:26: replace double_string -> String with String::new()
 src/simple_fns.rs:26: replace double_string -> String with "xyzzy".into()
 src/struct_with_lifetime.rs:14: replace Lex<'buf>::buf_len -> usize with Default::default()
 


### PR DESCRIPTION
- Inline Mutant::new
- Remove MutationOp enum
- Mutate functions returning `String` to `String::new()` rather than `"".into()`
