### PR TITLE
box syntax is no longer a nightly feature

### DIFF
--- a/testdata/tree/nightly_only/README.md
+++ b/testdata/tree/nightly_only/README.md
@@ -1,3 +1,5 @@
+# `nightly_only` test tree
+
 This tree only builds on nightly Rust, and can be used to check that `cargo
 mutants` uses the corresponding `cargo` and `rustc` when building candidates.
 

--- a/testdata/tree/nightly_only/src/lib.rs
+++ b/testdata/tree/nightly_only/src/lib.rs
@@ -1,0 +1,10 @@
+#![feature(box_patterns)]
+fn box_an_int() -> Box<i32> {
+    Box::new(5)
+}
+
+#[test]
+fn unbox_by_pattern() {
+    let box a = box_an_int();
+    assert_eq!(a, 5);
+}

--- a/testdata/tree/nightly_only/src/main.rs
+++ b/testdata/tree/nightly_only/src/main.rs
@@ -1,5 +1,0 @@
-#![feature(box_syntax)]
-fn main() {
-    let my_box = box 5;
-    println!("{}", *my_box);
-}

--- a/tests/cli/snapshots/cli__list_mutants_in_all_trees_as_json.snap
+++ b/tests/cli/snapshots/cli__list_mutants_in_all_trees_as_json.snap
@@ -244,11 +244,11 @@ expression: buf
 [
   {
     "package": "nightly_only",
-    "file": "src/main.rs",
+    "file": "src/lib.rs",
     "line": 2,
-    "function": "main",
-    "return_type": "",
-    "replacement": "()"
+    "function": "box_an_int",
+    "return_type": "-> Box<i32>",
+    "replacement": "Default::default()"
   }
 ]
 ```

--- a/tests/cli/snapshots/cli__list_mutants_in_all_trees_as_text.snap
+++ b/tests/cli/snapshots/cli__list_mutants_in_all_trees_as_text.snap
@@ -101,7 +101,7 @@ src/lib.rs:1: replace double -> u32 with Default::default()
 ## testdata/tree/nightly_only
 
 ```
-src/main.rs:2: replace main with ()
+src/lib.rs:2: replace box_an_int -> Box<i32> with Default::default()
 ```
 
 ## testdata/tree/override_dependency


### PR DESCRIPTION
It was dropped in https://github.com/rust-lang/rust/issues/49733
and isn't supported by new Syn.

box unpacking looks like a good substitute