### PR TITLE
book: fix links

### DIFF
--- a/book/src/vs-coverage.md
+++ b/book/src/vs-coverage.md
@@ -24,4 +24,4 @@ and prioritized.
 One drawback of mutation testing is that it runs the whole test suite once per
 generated mutant, so it can be slow on large trees with slow test suites. There
 are [some techniques to speed up cargo-mutants](performance.md), including
-[running multiple tests in parallel](parallel.md).
+[running multiple tests in parallel](parallelism.md).

--- a/book/src/welcome.md
+++ b/book/src/welcome.md
@@ -11,7 +11,7 @@ the tests might be insufficient.** ([More about these goals](goals.md).)
 
 To get started:
 
-1. [Install cargo-mutants](install.md).
+1. [Install cargo-mutants](installation.md).
 2. [Run `cargo mutants](getting-started.md) in your Rust source tree.
 
 For more resources see the repository at


### PR DESCRIPTION
Hi! Thank you for your cool project!

Noticed that installation page link on the welcome page is broken. I used [mdbook-linkcheck](https://github.com/Michael-F-Bryan/mdbook-linkcheck) crate to check all links and found one more broken one. 

I can try to poke around CI to integrate it if desirable