### PR TITLE
Update CI documentation to use parallelism

### DIFF
--- a/book/src/ci.md
+++ b/book/src/ci.md
@@ -11,6 +11,38 @@ jobs:
   cargo-mutants:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Install cargo-mutants
+        run: cargo install --locked cargo-mutants
+      - name: Run mutant tests
+        run: cargo mutants -- --all-features
+      - name: Archive results
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: mutation-report
+          path: mutants.out
+```
+
+The workflow used by cargo-mutants on itself can be seen at
+<https://github.com/sourcefrog/cargo-mutants/blob/main/.github/workflows/mutate-self.yaml>.
+
+## Parallelism
+
+If you'd like cargo-mutants to run in parallel (see [parallelism](parallelism.md) for more information) in CI, you can do the following:
+
+```yml
+name: cargo-mutants
+
+on: [pull_request, push]
+
+jobs:
+  cargo-mutants:
+    runs-on: ubuntu-latest
+    steps:
       - name: Get number of CPU cores
         uses: SimenB/github-actions-cpu-cores@v1
         id: cpu-cores
@@ -30,5 +62,4 @@ jobs:
           path: mutants.out
 ```
 
-The workflow used by cargo-mutants on itself can be seen at
-<https://github.com/sourcefrog/cargo-mutants/blob/main/.github/workflows/mutate-self.yaml>.
+This will automatically use the maximum number of CPU cores available. However, it's possible that this will result in flakiness due to OOM errors in the VM.

--- a/book/src/ci.md
+++ b/book/src/ci.md
@@ -11,6 +11,9 @@ jobs:
   cargo-mutants:
     runs-on: ubuntu-latest
     steps:
+      - name: Get number of CPU cores
+        uses: SimenB/github-actions-cpu-cores@v1
+        id: cpu-cores
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
@@ -18,7 +21,7 @@ jobs:
       - name: Install cargo-mutants
         run: cargo install --locked cargo-mutants
       - name: Run mutant tests
-        run: cargo mutants -- --all-features
+        run: cargo mutants --jobs ${{ steps.cpu-cores.outputs.count }} -- --all-features
       - name: Archive results
         uses: actions/upload-artifact@v3
         if: failure()


### PR DESCRIPTION
I did this for one of my repos and it halved the time it took to run, so figured I'd see if you'd want it in the documentation too.