### PR TITLE
Fix already_failing test

### DIFF
--- a/tests/cli/main.rs
+++ b/tests/cli/main.rs
@@ -935,21 +935,19 @@ fn already_failing_tests_are_detected_before_running_mutants() {
         .assert()
         .code(4)
         .stdout(
-            predicate::str::contains("running 1 test\ntest test_factorial ... FAILED").normalize(),
-        )
-        .stdout(
-            predicate::str::contains(
-                "thread 'test_factorial' panicked at 'assertion failed: `(left == right)`
-  left: `720`,
- right: `72`'",
-            )
-            .normalize(),
-        )
-        .stdout(predicate::str::contains("lib.rs:11:5"))
-        .stdout(predicate::str::contains(
-            "cargo test failed in an unmutated tree, so no mutants were tested",
-        ))
-        .stdout(predicate::str::contains("test result: FAILED. 0 passed; 1 failed;").normalize());
+            predicate::str::contains("running 1 test\ntest test_factorial ... FAILED")
+                .normalize()
+                .and(predicate::str::contains("thread 'test_factorial' panicked"))
+                .and(predicate::str::contains("72")) // the failing value should be in the output
+                .and(predicate::str::contains("lib.rs:11:5"))
+                .and(predicate::str::contains(
+                    "cargo test failed in an unmutated tree, so no mutants were tested",
+                ))
+                .and(
+                    predicate::str::contains("test result: FAILED. 0 passed; 1 failed;")
+                        .normalize(),
+                ),
+        );
 }
 
 #[test]


### PR DESCRIPTION
Some of the rust testsuite output failed and the test was a bit brittle.