### PR TITLE
Fix finding the workspace root from a subdirectory

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # cargo-mutants changelog
 
+## Unreleased
+
+- Fixed a bug causing an assertion failure when cargo-mutants was run from a
+  subdirectory of a workspace.
+
 ## 23.6.0
 
 - Generate `Box::leak(Box::new(...))` as a mutation of functions returning

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,8 +3,8 @@
 ## Unreleased
 
 - Fixed a bug causing an assertion failure when cargo-mutants was run from a
-  subdirectory of a workspace.
-
+  subdirectory of a workspace. Thanks to Adam Chalmers!
+ 
 ## 23.6.0
 
 - Generate `Box::leak(Box::new(...))` as a mutation of functions returning

--- a/book/src/workspaces.md
+++ b/book/src/workspaces.md
@@ -4,6 +4,8 @@ cargo-mutants supports testing Cargo workspaces that contain multiple packages. 
 
 By default, all source files in all packages in the workspace are tested.
 
+**NOTE: This behavior might not be the best choice, and this may change in future.**
+
 You can use the `--file` options to restrict cargo-mutants to testing only files
 from some subdirectory, e.g. with `-f "utils/**/*.rs"`. (Remember to quote globs
 on the command line, so that the shell doesn't expand them.) You can use `--list` or

--- a/book/src/workspaces.md
+++ b/book/src/workspaces.md
@@ -2,6 +2,12 @@
 
 cargo-mutants supports testing Cargo workspaces that contain multiple packages. The entire workspace tree is copied.
 
-All source files in all packages in the workspace are tested.
+By default, all source files in all packages in the workspace are tested.
 
-For each mutant, only the containing package's tests are run, on the theory that each package's tests are responsible for testing the package's code.
+You can use the `--file` options to restrict cargo-mutants to testing only files
+from some subdirectory, e.g. with `-f "utils/**/*.rs"`. (Remember to quote globs
+on the command line, so that the shell doesn't expand them.) You can use `--list` or
+`--list-files` to preview the effect of filters.
+
+For each mutant, only the containing package's tests are run, on the theory that
+each package's tests are responsible for testing the package's code.

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -83,7 +83,7 @@ impl Tool for CargoTool {
     /// After this, there is one more level of discovery, by walking those root files
     /// to find `mod` statements, and then recursively walking those files to find
     /// all source files.
-    fn root_files(&self, source_root_path: &Utf8Path) -> Result<Vec<Arc<SourceFile>>> {
+    fn top_source_files(&self, source_root_path: &Utf8Path) -> Result<Vec<Arc<SourceFile>>> {
         let cargo_toml_path = source_root_path.join("Cargo.toml");
         debug!(?cargo_toml_path, ?source_root_path, "Find root files");
         check_interrupted()?;
@@ -380,15 +380,15 @@ mod test {
     }
 
     #[test]
-    fn find_root_files_from_subdirectory_of_workspace() {
+    fn find_top_source_files_from_subdirectory_of_workspace() {
         let tool = CargoTool::new();
         let root_dir = tool
             .find_root(Utf8Path::new("testdata/tree/workspace/main"))
             .expect("Find workspace root");
-        let root_files = tool.root_files(&root_dir).expect("Find root files");
-        println!("{root_files:#?}");
-        assert_eq!(root_files.len(), 3);
-        let paths: Vec<String> = root_files
+        let top_source_files = tool.top_source_files(&root_dir).expect("Find root files");
+        println!("{top_source_files:#?}");
+        assert_eq!(top_source_files.len(), 3);
+        let paths: Vec<String> = top_source_files
             .iter()
             .map(|sf| sf.tree_relative_path.to_string())
             .sorted()

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -78,11 +78,13 @@ impl Tool for CargoTool {
         for package_metadata in &metadata.workspace_packages() {
             check_interrupted()?;
             let _span = debug_span!("package", name = %package_metadata.name).entered();
-            debug!(manifest_path = %package_metadata.manifest_path, "walk package");
-            let relative_manifest_path = package_metadata
-                .manifest_path
+            let manifest_path = &package_metadata.manifest_path;
+            debug!(%manifest_path, "walk package");
+            let relative_manifest_path = manifest_path
                 .strip_prefix(source_root_path)
-                .expect("manifest_path is within source_root_path")
+                .with_context(|| format!(
+                    "manifest path {manifest_path} is not within the detected source root path {source_root_path}"
+                ))?
                 .to_owned();
             let package = Arc::new(Package {
                 name: package_metadata.name.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -270,7 +270,8 @@ fn list_files(tool: &dyn Tool, source: &Utf8Path, options: &Options, json: bool)
                 })
                 .collect(),
         );
-        serde_json::to_writer_pretty(out, &json_list)?;
+        serde_json::to_writer_pretty(&mut out, &json_list)?;
+        writeln!(out)?;
     } else {
         for file in discovered.files {
             writeln!(out, "{}", file.tree_relative_path)?;

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -47,7 +47,7 @@ pub fn walk_tree(tool: &dyn Tool, root: &Utf8Path, options: &Options) -> Result<
         .collect::<Result<Vec<Expr>>>()?;
     let mut mutants = Vec::new();
     let mut files: Vec<Arc<SourceFile>> = Vec::new();
-    let mut file_queue: VecDeque<Arc<SourceFile>> = tool.root_files(root)?.into();
+    let mut file_queue: VecDeque<Arc<SourceFile>> = tool.top_source_files(root)?.into();
     while let Some(source_file) = file_queue.pop_front() {
         check_interrupted()?;
         let (mut file_mutants, more_files) =

--- a/tests/cli/main.rs
+++ b/tests/cli/main.rs
@@ -458,6 +458,30 @@ fn list_files_json_workspace() {
 }
 
 #[test]
+fn list_files_as_json_in_workspace_subdir() {
+    run()
+        .args(["mutants", "--list-files", "--json"])
+        .current_dir("testdata/tree/workspace/main2")
+        .assert()
+        .stdout(indoc! {r#"
+            [
+              {
+                "package": "cargo_mutants_testdata_workspace_utils",
+                "path": "utils/src/lib.rs"
+              },
+              {
+                "package": "main",
+                "path": "main/src/main.rs"
+              },
+              {
+                "package": "main2",
+                "path": "main2/src/main.rs"
+              }
+            ]
+        "#});
+}
+
+#[test]
 fn workspace_tree_is_well_tested() {
     let tmp_src_dir = copy_of_testdata("workspace");
     run()


### PR DESCRIPTION
- Better error message about finding workspace paths
- Clean up error messages
- Pass --workspace to cargo locate-project
- Tests for finding workspace from subdirectory
- Trailing newline in --list-files --json
- News for workspace fix
- Test --list-files --json in workspace subdir
- More docs about workspaces
- Thanks Adam!
