### PR TITLE
Use CargoMetadata::no_deps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # cargo-mutants changelog
 
+## Unreleased
+
+- Improved: Run `cargo metadata` with `--no-deps`, so that it doesn't download and compute dependency information, which can save time in some situations.
+
 ## 23.11.1
 
 - New `--in-diff FILE` option tests only mutants that are in the diff from the

--- a/src/output.rs
+++ b/src/output.rs
@@ -286,7 +286,6 @@ mod test {
             list_recursive(tmp.path()),
             &[
                 "",
-                "Cargo.lock",
                 "Cargo.toml",
                 "mutants.out",
                 "mutants.out/caught.txt",

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -113,6 +113,7 @@ impl Workspace {
         debug!(?cargo_toml_path, ?dir, "Find root files");
         check_interrupted()?;
         let metadata = cargo_metadata::MetadataCommand::new()
+            .no_deps()
             .manifest_path(&cargo_toml_path)
             .exec()
             .context("run cargo metadata")?;


### PR DESCRIPTION
Sometimes `cargo metadata` spends a lot of time updating dependency
information, and we don't need it: we're only
interested in packages in the workspace.

Fixes #164