### PR TITLE
Incremental runs

### DIFF
--- a/src/incremental.rs
+++ b/src/incremental.rs
@@ -1,0 +1,44 @@
+// Copyright 2023 Paxos
+
+//! Logic for incremantal runs
+use crate::{
+    mutate::{Mutant, MutantHash},
+    options::Options,
+    output::{PositiveOutcome, OUTDIR_NAME, POSITIVE_OUTCOMES_FILE},
+};
+use anyhow::{anyhow, Result};
+use camino::{Utf8Path, Utf8PathBuf};
+use std::{collections::HashSet, fs};
+
+pub fn filter_by_last_positive_outcomes(
+    mutants: Vec<Mutant>,
+    dir: &Utf8PathBuf,
+    options: &Options,
+) -> (Option<Vec<PositiveOutcome>>, Vec<Mutant>) {
+    let read_path: &Utf8Path = options.output_in_dir.as_ref().map_or(dir, |p| p.as_path());
+    // TODO: add logging here for error cases
+    let last_positive_outcomes = match read_last_positive_outcomes(read_path) {
+        Ok(outcomes) => Some(outcomes),
+        Err(_) => None,
+    };
+    // if last_positive_outcomes is none the hash set will be empty thereby allowing all mutants to be considered
+    let existing_mutants: HashSet<MutantHash> = last_positive_outcomes
+        .iter()
+        .flatten()
+        .map(|o| o.mutant_hash())
+        .collect();
+    let mutants = mutants
+        .into_iter()
+        .filter(|m| !existing_mutants.contains(&m.calculate_hash()))
+        .collect();
+    (last_positive_outcomes, mutants)
+}
+
+fn read_last_positive_outcomes(read_path: &Utf8Path) -> Result<Vec<PositiveOutcome>> {
+    let path = read_path.join(OUTDIR_NAME).join(POSITIVE_OUTCOMES_FILE);
+    fs::read_to_string(path.clone())
+        .map(|contents| serde_json::from_str(&contents).map_err(|e| anyhow!("{}", e)))
+        // If we can’t read the file, we assume that it doesn’t exist and we return an empty list.
+        // Later, the file will get written and any error will be surfaced to the user.
+        .unwrap_or(Ok(vec![]))
+}

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -16,7 +16,7 @@ use tracing::{debug, debug_span, error, info, trace};
 use crate::cargo::run_cargo;
 use crate::console::Console;
 use crate::outcome::{LabOutcome, Phase, ScenarioOutcome};
-use crate::output::OutputDir;
+use crate::output::{OutputDir, PositiveOutcome};
 use crate::package::Package;
 use crate::*;
 
@@ -29,13 +29,14 @@ pub fn test_mutants(
     workspace_dir: &Utf8Path,
     options: Options,
     console: &Console,
+    last_positive_outcomes: Option<Vec<PositiveOutcome>>,
 ) -> Result<LabOutcome> {
     let start_time = Instant::now();
     let output_in_dir: &Utf8Path = options
         .output_in_dir
         .as_ref()
         .map_or(workspace_dir, |p| p.as_path());
-    let output_dir = OutputDir::new(output_in_dir)?;
+    let output_dir = OutputDir::new(output_in_dir, last_positive_outcomes)?;
     console.set_debug_log(output_dir.open_debug_log()?);
 
     if options.shuffle {

--- a/src/outcome.rs
+++ b/src/outcome.rs
@@ -9,6 +9,7 @@ use std::time::Instant;
 
 use anyhow::Context;
 use serde::ser::SerializeStruct;
+use serde::Deserialize;
 use serde::Serialize;
 use serde::Serializer;
 
@@ -294,7 +295,7 @@ impl Serialize for PhaseResult {
 }
 
 /// Overall summary outcome for one mutant.
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Hash)]
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq, Serialize, Hash)]
 pub enum SummaryOutcome {
     Success,
     CaughtMutant,

--- a/src/snapshots/cargo_mutants__visit__test__expected_mutants_for_own_source_tree.snap
+++ b/src/snapshots/cargo_mutants__visit__test__expected_mutants_for_own_source_tree.snap
@@ -164,6 +164,15 @@ src/in_diff.rs: replace partial_new_file -> Vec<(usize, &'d str)> with vec![(0, 
 src/in_diff.rs: replace partial_new_file -> Vec<(usize, &'d str)> with vec![(0, "xyzzy")]
 src/in_diff.rs: replace partial_new_file -> Vec<(usize, &'d str)> with vec![(1, "")]
 src/in_diff.rs: replace partial_new_file -> Vec<(usize, &'d str)> with vec![(1, "xyzzy")]
+src/incremental.rs: replace filter_by_last_positive_outcomes -> (Option<Vec<PositiveOutcome>>, Vec<Mutant>) with (None, vec![])
+src/incremental.rs: replace filter_by_last_positive_outcomes -> (Option<Vec<PositiveOutcome>>, Vec<Mutant>) with (None, vec![Default::default()])
+src/incremental.rs: replace filter_by_last_positive_outcomes -> (Option<Vec<PositiveOutcome>>, Vec<Mutant>) with (Some(vec![]), vec![])
+src/incremental.rs: replace filter_by_last_positive_outcomes -> (Option<Vec<PositiveOutcome>>, Vec<Mutant>) with (Some(vec![]), vec![Default::default()])
+src/incremental.rs: replace filter_by_last_positive_outcomes -> (Option<Vec<PositiveOutcome>>, Vec<Mutant>) with (Some(vec![Default::default()]), vec![])
+src/incremental.rs: replace filter_by_last_positive_outcomes -> (Option<Vec<PositiveOutcome>>, Vec<Mutant>) with (Some(vec![Default::default()]), vec![Default::default()])
+src/incremental.rs: replace read_last_positive_outcomes -> Result<Vec<PositiveOutcome>> with Ok(vec![])
+src/incremental.rs: replace read_last_positive_outcomes -> Result<Vec<PositiveOutcome>> with Ok(vec![Default::default()])
+src/incremental.rs: replace read_last_positive_outcomes -> Result<Vec<PositiveOutcome>> with Err(::anyhow::anyhow!("mutated!"))
 src/interrupt.rs: replace install_handler with ()
 src/lab.rs: replace test_mutants -> Result<LabOutcome> with Ok(Default::default())
 src/lab.rs: replace test_mutants -> Result<LabOutcome> with Err(::anyhow::anyhow!("mutated!"))
@@ -248,6 +257,7 @@ src/mutate.rs: replace Mutant::write_in_dir -> Result<()> with Ok(())
 src/mutate.rs: replace Mutant::write_in_dir -> Result<()> with Err(::anyhow::anyhow!("mutated!"))
 src/mutate.rs: replace Mutant::log_file_name_base -> String with String::new()
 src/mutate.rs: replace Mutant::log_file_name_base -> String with "xyzzy".into()
+src/mutate.rs: replace Mutant::calculate_hash -> MutantHash with Default::default()
 src/mutate.rs: replace <impl Debug for Mutant>::fmt -> fmt::Result with Ok(Default::default())
 src/mutate.rs: replace <impl Debug for Mutant>::fmt -> fmt::Result with Err(::anyhow::anyhow!("mutated!"))
 src/mutate.rs: replace <impl Serialize for Mutant>::serialize -> Result<S::Ok, S::Error> with Ok(Default::default())
@@ -308,6 +318,8 @@ src/output.rs: replace == with != in LockFile::acquire_lock
 src/output.rs: replace OutputDir::create_log -> Result<LogFile> with Ok(Default::default())
 src/output.rs: replace OutputDir::create_log -> Result<LogFile> with Err(::anyhow::anyhow!("mutated!"))
 src/output.rs: replace OutputDir::path -> &Utf8Path with &Default::default()
+src/output.rs: replace OutputDir::maybe_write_positive_outcomes -> Result<()> with Ok(())
+src/output.rs: replace OutputDir::maybe_write_positive_outcomes -> Result<()> with Err(::anyhow::anyhow!("mutated!"))
 src/output.rs: replace OutputDir::write_lab_outcome -> Result<()> with Ok(())
 src/output.rs: replace OutputDir::write_lab_outcome -> Result<()> with Err(::anyhow::anyhow!("mutated!"))
 src/output.rs: replace OutputDir::add_scenario_outcome -> Result<()> with Ok(())
@@ -317,6 +329,9 @@ src/output.rs: replace OutputDir::open_debug_log -> Result<File> with Err(::anyh
 src/output.rs: replace OutputDir::write_mutants_list -> Result<()> with Ok(())
 src/output.rs: replace OutputDir::write_mutants_list -> Result<()> with Err(::anyhow::anyhow!("mutated!"))
 src/output.rs: replace OutputDir::take_lab_outcome -> LabOutcome with Default::default()
+src/output.rs: replace PositiveOutcome::mutant_hash -> MutantHash with Default::default()
+src/output.rs: replace <impl TryFrom for PositiveOutcome>::try_from -> Result<Self> with Ok(Default::default())
+src/output.rs: replace <impl TryFrom for PositiveOutcome>::try_from -> Result<Self> with Err(::anyhow::anyhow!("mutated!"))
 src/path.rs: replace ascent -> isize with 0
 src/path.rs: replace ascent -> isize with 1
 src/path.rs: replace ascent -> isize with -1

--- a/src/source.rs
+++ b/src/source.rs
@@ -19,7 +19,7 @@ use crate::path::Utf8PathSlashes;
 ///
 /// Code is normalized to Unix line endings as it's read in, and modified
 /// files are written with Unix line endings.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Hash)]
 pub struct SourceFile {
     /// Package within the workspace.
     pub package: Arc<Package>,

--- a/src/span.rs
+++ b/src/span.rs
@@ -11,7 +11,7 @@ use std::fmt;
 use serde::Serialize;
 
 /// A (line, column) position in a source file.
-#[derive(Clone, Copy, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Eq, Hash, PartialEq, Serialize)]
 pub struct LineColumn {
     /// 1-based line number.
     pub line: usize,
@@ -36,7 +36,7 @@ impl fmt::Debug for LineColumn {
 }
 
 /// A contiguous text span in a file.
-#[derive(Clone, Copy, Eq, PartialEq, Serialize)]
+#[derive(Clone, Copy, Eq, Hash, PartialEq, Serialize)]
 pub struct Span {
     /// The *inclusive* position where the span starts.
     pub start: LineColumn,


### PR DESCRIPTION
This is a work in progress PR to add incremental runs (#53). @jared-norris is working with me on this as a part of a hackathon at our company.

## TODO
- [ ] Add tests
- [x] Write the logic in the new incremental module
- [ ] Write user facing doc

## High level description

Our vision of the use case for incremental builds is that you will add some code, try to cover it and you will have, say, 10 unviable mutants, 7 caught mutants and 3 uncaught mutants. You will then add tests, trying to catch those 3 mutants and you will run `cargo mutants` multiple time, catching more and more, until all mutants are either unviable or caught. That last part, where you keep adding tests, is where there is an opportunity to do incremental builds, where only the 3 uncaught mutants will be tried, ignoring the 10 unviable and the 7 caught mutants.

We are adding a flag to run `cargo mutants` incrementally.
1. The first time the tool is called with the incremental flag, we do a normal run and save a list to mutants that were caught by tests or unviable. We call the scenarios associated with those mutants *positive outcomes*.
2. The second time onward the tool is called with incremental flag, we load the previously saved list of positive outcomes and use it to exclude all mutants that were previously caught or unviable. If any more mutants are caught, they are added to the list of positive outcomes and all the positive outcomes, both from the current run and from previous runs are saved back.
3. The next time the tool is called without the incremental flag, the list of positive outcomes is not written and it gets removed as a part of the process that rotates `mutants.out` to `mutants.out.old`.