### PR TITLE
Correctly walk from atypically named top files using the target `path`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,7 @@ exclude = [
     "testdata/cdylib",
     "testdata/cfg_attr_mutants_skip",
     "testdata/cfg_attr_test_skip",
+    "testdata/custom_top_file",
     "testdata/dependency",
     "testdata/diff0",
     "testdata/diff1",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fixed: Correctly traverse `mod` statements within package top source files that are not named `lib.rs` or `main.rs`.
+- Fixed: Correctly traverse `mod` statements within package top source files that are not named `lib.rs` or `main.rs`, by following the `path` setting of each target within the manifest.
 
 ## 23.12.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # cargo-mutants changelog
 
+## Unreleased
+
+- Fixed: Correctly traverse `mod` statements within package top source files that are not named `lib.rs` or `main.rs`.
+
 ## 23.12.0
 
 An exciting step forward: cargo-mutants can now generate mutations smaller than a whole function. To start with, several binary operators are mutated.

--- a/src/snapshots/cargo_mutants__visit__test__expected_mutants_for_own_source_tree.snap
+++ b/src/snapshots/cargo_mutants__visit__test__expected_mutants_for_own_source_tree.snap
@@ -609,9 +609,6 @@ src/visit.rs: replace find_mod_source -> Result<Option<Utf8PathBuf>> with Err(::
 src/visit.rs: replace || with && in find_mod_source
 src/visit.rs: replace || with == in find_mod_source
 src/visit.rs: replace || with != in find_mod_source
-src/visit.rs: replace || with && in find_mod_source
-src/visit.rs: replace || with == in find_mod_source
-src/visit.rs: replace || with != in find_mod_source
 src/visit.rs: replace fn_sig_excluded -> bool with true
 src/visit.rs: replace fn_sig_excluded -> bool with false
 src/visit.rs: replace attrs_excluded -> bool with true

--- a/src/source.rs
+++ b/src/source.rs
@@ -29,6 +29,10 @@ pub struct SourceFile {
 
     /// Full copy of the source.
     pub code: String,
+
+    /// True if this is the top source file for its target: typically but
+    /// not always `lib.rs` or `main.rs`.
+    pub is_top: bool,
 }
 
 impl SourceFile {
@@ -39,6 +43,7 @@ impl SourceFile {
         tree_path: &Utf8Path,
         tree_relative_path: Utf8PathBuf,
         package: &Arc<Package>,
+        is_top: bool,
     ) -> Result<SourceFile> {
         let full_path = tree_path.join(&tree_relative_path);
         let code = std::fs::read_to_string(&full_path)
@@ -48,6 +53,7 @@ impl SourceFile {
             tree_relative_path,
             code,
             package: Arc::clone(package),
+            is_top,
         })
     }
 
@@ -87,6 +93,7 @@ mod test {
                 name: "imaginary-package".to_owned(),
                 relative_manifest_path: "whatever/Cargo.toml".into(),
             }),
+            true,
         )
         .unwrap();
         assert_eq!(source_file.code, "fn main() {\n    640 << 10;\n}\n");

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -194,6 +194,7 @@ impl Workspace {
                     &self.dir,
                     source_path.to_owned(),
                     &package,
+                    true,
                 )?));
             }
         }

--- a/testdata/custom_top_file/Cargo.toml
+++ b/testdata/custom_top_file/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "cargo-mutants-testdata-custom-top-file"
+description = "A package that overrides the default file name for a target"
+version = "0.0.0"
+edition = "2018"
+authors = ["Martin Pool"]
+publish = false
+
+[lib]
+doctest = false
+path = "src/custom_top.rs"

--- a/testdata/custom_top_file/src/custom_top.rs
+++ b/testdata/custom_top_file/src/custom_top.rs
@@ -1,0 +1,14 @@
+pub fn is_even(n: u32) -> bool {
+    n % 2 == 0
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_is_even() {
+        assert!(is_even(2));
+        assert!(!is_even(3));
+    }
+}

--- a/tests/cli/snapshots/cli__list_mutants_in_all_trees_as_json.snap
+++ b/tests/cli/snapshots/cli__list_mutants_in_all_trees_as_json.snap
@@ -313,6 +313,103 @@ expression: buf
 ]
 ```
 
+## testdata/custom_top_file
+
+```json
+[
+  {
+    "file": "src/custom_top.rs",
+    "function": {
+      "function_name": "is_even",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 6
+        },
+        "start": {
+          "column": 1,
+          "line": 4
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-custom-top-file",
+    "replacement": "true",
+    "span": {
+      "end": {
+        "column": 15,
+        "line": 5
+      },
+      "start": {
+        "column": 5,
+        "line": 5
+      }
+    }
+  },
+  {
+    "file": "src/custom_top.rs",
+    "function": {
+      "function_name": "is_even",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 6
+        },
+        "start": {
+          "column": 1,
+          "line": 4
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-custom-top-file",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 15,
+        "line": 5
+      },
+      "start": {
+        "column": 5,
+        "line": 5
+      }
+    }
+  },
+  {
+    "file": "src/custom_top.rs",
+    "function": {
+      "function_name": "is_even",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 6
+        },
+        "start": {
+          "column": 1,
+          "line": 4
+        }
+      }
+    },
+    "genre": "BinaryOperator",
+    "package": "cargo-mutants-testdata-custom-top-file",
+    "replacement": "!=",
+    "span": {
+      "end": {
+        "column": 13,
+        "line": 5
+      },
+      "start": {
+        "column": 11,
+        "line": 5
+      }
+    }
+  }
+]
+```
+
 ## testdata/dependency
 
 ```json

--- a/tests/cli/snapshots/cli__list_mutants_in_all_trees_as_text.snap
+++ b/tests/cli/snapshots/cli__list_mutants_in_all_trees_as_text.snap
@@ -41,6 +41,14 @@ src/lib.rs:18:5: replace double -> usize with 0
 src/lib.rs:18:5: replace double -> usize with 1
 ```
 
+## testdata/custom_top_file
+
+```
+src/custom_top.rs:5:5: replace is_even -> bool with true
+src/custom_top.rs:5:5: replace is_even -> bool with false
+src/custom_top.rs:5:11: replace == with != in is_even
+```
+
 ## testdata/dependency
 
 ```


### PR DESCRIPTION
Remember whether the file is a target top, rather than relying on the file name.

Fixes #115 

- [x] Tests with a Cargo.toml using the target `path` feature