### PR TITLE
Avoid generating no-op mutants

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # cargo-mutants changelog
 
+## Unreleased
+
+- Improved: Don't generate function mutants that have the same AST as the code they're replacing.
+
 ## 23.12.0
 
 An exciting step forward: cargo-mutants can now generate mutations smaller than a whole function. To start with, several binary operators are mutated.

--- a/src/fnvalue.rs
+++ b/src/fnvalue.rs
@@ -17,12 +17,11 @@ use tracing::trace;
 pub(crate) fn return_type_replacements(
     return_type: &ReturnType,
     error_exprs: &[Expr],
-) -> impl Iterator<Item = TokenStream> {
+) -> Vec<TokenStream> {
     match return_type {
         ReturnType::Default => vec![quote! { () }],
         ReturnType::Type(_rarrow, type_) => type_replacements(type_, error_exprs).collect_vec(),
     }
-    .into_iter()
 }
 
 /// Generate some values that we hope are reasonable replacements for a type.
@@ -696,6 +695,7 @@ mod test {
     fn check_replacements(return_type: ReturnType, error_exprs: &[Expr], expected: &[&str]) {
         assert_eq!(
             return_type_replacements(&return_type, error_exprs)
+                .into_iter()
                 .map(|t| t.to_pretty_string())
                 .collect_vec(),
             expected

--- a/src/list.rs
+++ b/src/list.rs
@@ -4,7 +4,6 @@
 
 use std::fmt;
 use std::io;
-use std::sync::Arc;
 
 use serde_json::{json, Value};
 
@@ -62,7 +61,7 @@ pub(crate) fn list_mutants<W: fmt::Write>(
 
 pub(crate) fn list_files<W: fmt::Write>(
     mut out: W,
-    source_files: &[Arc<SourceFile>],
+    source_files: &[SourceFile],
     options: &Options,
 ) -> Result<()> {
     if options.emit_json {

--- a/src/mutate.rs
+++ b/src/mutate.rs
@@ -31,7 +31,7 @@ pub enum Genre {
 #[derive(Clone, Eq, PartialEq)]
 pub struct Mutant {
     /// Which file is being mutated.
-    pub source_file: Arc<SourceFile>,
+    pub source_file: SourceFile,
 
     /// The function that's being mutated: the nearest enclosing function, if they are nested.
     ///
@@ -71,7 +71,7 @@ impl Mutant {
     /// Return text of the whole file with the mutation applied.
     pub fn mutated_code(&self) -> String {
         self.span.replace(
-            &self.source_file.code,
+            self.source_file.code(),
             &format!("{} {}", &self.replacement, MUTATION_MARKER_COMMENT),
         )
     }
@@ -143,7 +143,7 @@ impl Mutant {
     }
 
     pub fn original_text(&self) -> String {
-        self.span.extract(&self.source_file.code)
+        self.span.extract(self.source_file.code())
     }
 
     /// Return the text inserted for this mutation.
@@ -165,7 +165,7 @@ impl Mutant {
         let old_label = self.source_file.tree_relative_slashes();
         // There shouldn't be any newlines, but just in case...
         let new_label = self.describe_change().replace('\n', " ");
-        TextDiff::from_lines(&self.source_file.code, &self.mutated_code())
+        TextDiff::from_lines(self.source_file.code(), &self.mutated_code())
             .unified_diff()
             .context_radius(8)
             .header(&old_label, &new_label)
@@ -178,7 +178,7 @@ impl Mutant {
     }
 
     pub fn unapply(&self, build_dir: &mut BuildDir) -> Result<()> {
-        self.write_in_dir(build_dir, &self.source_file.code)
+        self.write_in_dir(build_dir, self.source_file.code())
     }
 
     #[allow(unknown_lints, clippy::needless_pass_by_ref_mut)]

--- a/src/snapshots/cargo_mutants__visit__test__expected_mutants_for_own_source_tree.snap
+++ b/src/snapshots/cargo_mutants__visit__test__expected_mutants_for_own_source_tree.snap
@@ -68,7 +68,6 @@ src/console.rs: replace <impl MakeWriter for TerminalWriter>::make_writer -> Sel
 src/console.rs: replace <impl Write for TerminalWriter>::write -> std::io::Result<usize> with Ok(0)
 src/console.rs: replace <impl Write for TerminalWriter>::write -> std::io::Result<usize> with Ok(1)
 src/console.rs: replace <impl Write for TerminalWriter>::write -> std::io::Result<usize> with Err(::anyhow::anyhow!("mutated!"))
-src/console.rs: replace <impl Write for TerminalWriter>::flush -> std::io::Result<()> with Ok(())
 src/console.rs: replace <impl Write for TerminalWriter>::flush -> std::io::Result<()> with Err(::anyhow::anyhow!("mutated!"))
 src/console.rs: replace <impl MakeWriter for DebugLogWriter>::make_writer -> Self::Writer with Default::default()
 src/console.rs: replace <impl Write for DebugLogWriter>::write -> io::Result<usize> with Ok(0)
@@ -572,6 +571,7 @@ src/visit.rs: replace DiscoveryVisitor<'o>::enter_function -> Arc<Function> with
 src/visit.rs: replace DiscoveryVisitor<'o>::leave_function with ()
 src/visit.rs: replace DiscoveryVisitor<'o>::collect_mutant with ()
 src/visit.rs: replace DiscoveryVisitor<'o>::collect_fn_mutants with ()
+src/visit.rs: replace == with != in DiscoveryVisitor<'o>::collect_fn_mutants
 src/visit.rs: replace DiscoveryVisitor<'o>::in_namespace -> T with Default::default()
 src/visit.rs: replace <impl Visit for DiscoveryVisitor<'_>>::visit_item_fn with ()
 src/visit.rs: replace || with && in <impl Visit for DiscoveryVisitor<'_>>::visit_item_fn

--- a/src/snapshots/cargo_mutants__visit__test__expected_mutants_for_own_source_tree.snap
+++ b/src/snapshots/cargo_mutants__visit__test__expected_mutants_for_own_source_tree.snap
@@ -140,8 +140,8 @@ src/copy_tree.rs: replace copy_tree -> Result<TempDir> with Ok(Default::default(
 src/copy_tree.rs: replace copy_tree -> Result<TempDir> with Err(::anyhow::anyhow!("mutated!"))
 src/copy_tree.rs: replace copy_symlink -> Result<()> with Ok(())
 src/copy_tree.rs: replace copy_symlink -> Result<()> with Err(::anyhow::anyhow!("mutated!"))
-src/fnvalue.rs: replace return_type_replacements -> impl Iterator<Item = TokenStream> with ::std::iter::empty()
-src/fnvalue.rs: replace return_type_replacements -> impl Iterator<Item = TokenStream> with ::std::iter::once(Default::default())
+src/fnvalue.rs: replace return_type_replacements -> Vec<TokenStream> with vec![]
+src/fnvalue.rs: replace return_type_replacements -> Vec<TokenStream> with vec![Default::default()]
 src/fnvalue.rs: replace type_replacements -> impl Iterator<Item = TokenStream> with ::std::iter::empty()
 src/fnvalue.rs: replace type_replacements -> impl Iterator<Item = TokenStream> with ::std::iter::once(Default::default())
 src/fnvalue.rs: replace path_ends_with -> bool with true
@@ -466,6 +466,8 @@ src/scenario.rs: replace Scenario::log_file_name_base -> String with "xyzzy".int
 src/source.rs: replace SourceFile::tree_relative_slashes -> String with String::new()
 src/source.rs: replace SourceFile::tree_relative_slashes -> String with "xyzzy".into()
 src/source.rs: replace SourceFile::path -> &Utf8Path with &Default::default()
+src/source.rs: replace SourceFile::code -> &str with ""
+src/source.rs: replace SourceFile::code -> &str with "xyzzy"
 src/span.rs: replace <impl From for LineColumn>::from -> Self with Default::default()
 src/span.rs: replace <impl Debug for LineColumn>::fmt -> fmt::Result with Ok(Default::default())
 src/span.rs: replace <impl Debug for LineColumn>::fmt -> fmt::Result with Err(::anyhow::anyhow!("mutated!"))
@@ -568,6 +570,7 @@ src/visit.rs: replace walk_file -> Result<(Vec<Mutant>, Vec<String>)> with Ok((v
 src/visit.rs: replace walk_file -> Result<(Vec<Mutant>, Vec<String>)> with Err(::anyhow::anyhow!("mutated!"))
 src/visit.rs: replace DiscoveryVisitor<'o>::enter_function -> Arc<Function> with Arc::new(Default::default())
 src/visit.rs: replace DiscoveryVisitor<'o>::leave_function with ()
+src/visit.rs: replace DiscoveryVisitor<'o>::collect_mutant with ()
 src/visit.rs: replace DiscoveryVisitor<'o>::collect_fn_mutants with ()
 src/visit.rs: replace DiscoveryVisitor<'o>::in_namespace -> T with Default::default()
 src/visit.rs: replace <impl Visit for DiscoveryVisitor<'_>>::visit_item_fn with ()
@@ -645,9 +648,9 @@ src/workspace.rs: replace Workspace::package_tops -> Result<Vec<PackageTop>> wit
 src/workspace.rs: replace Workspace::package_tops -> Result<Vec<PackageTop>> with Ok(vec![Default::default()])
 src/workspace.rs: replace Workspace::package_tops -> Result<Vec<PackageTop>> with Err(::anyhow::anyhow!("mutated!"))
 src/workspace.rs: replace == with != in Workspace::package_tops
-src/workspace.rs: replace Workspace::top_sources -> Result<Vec<Arc<SourceFile>>> with Ok(vec![])
-src/workspace.rs: replace Workspace::top_sources -> Result<Vec<Arc<SourceFile>>> with Ok(vec![Arc::new(Default::default())])
-src/workspace.rs: replace Workspace::top_sources -> Result<Vec<Arc<SourceFile>>> with Err(::anyhow::anyhow!("mutated!"))
+src/workspace.rs: replace Workspace::top_sources -> Result<Vec<SourceFile>> with Ok(vec![])
+src/workspace.rs: replace Workspace::top_sources -> Result<Vec<SourceFile>> with Ok(vec![Default::default()])
+src/workspace.rs: replace Workspace::top_sources -> Result<Vec<SourceFile>> with Err(::anyhow::anyhow!("mutated!"))
 src/workspace.rs: replace Workspace::discover -> Result<Discovered> with Ok(Default::default())
 src/workspace.rs: replace Workspace::discover -> Result<Discovered> with Err(::anyhow::anyhow!("mutated!"))
 src/workspace.rs: replace Workspace::mutants -> Result<Vec<Mutant>> with Ok(vec![])

--- a/src/source.rs
+++ b/src/source.rs
@@ -19,7 +19,7 @@ use crate::path::Utf8PathSlashes;
 ///
 /// Code is normalized to Unix line endings as it's read in, and modified
 /// files are written with Unix line endings.
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SourceFile {
     /// Package within the workspace.
     pub package: Arc<Package>,
@@ -27,8 +27,11 @@ pub struct SourceFile {
     /// Path of this source file relative to workspace.
     pub tree_relative_path: Utf8PathBuf,
 
-    /// Full copy of the source.
-    pub code: String,
+    /// Full copy of the unmodified source.
+    ///
+    /// This is held in an [Arc] so that SourceFiles can be cloned without using excessive
+    /// amounts of memory.
+    code: Arc<String>,
 }
 
 impl SourceFile {
@@ -41,9 +44,11 @@ impl SourceFile {
         package: &Arc<Package>,
     ) -> Result<SourceFile> {
         let full_path = tree_path.join(&tree_relative_path);
-        let code = std::fs::read_to_string(&full_path)
-            .with_context(|| format!("failed to read source of {full_path:?}"))?
-            .replace("\r\n", "\n");
+        let code = Arc::new(
+            std::fs::read_to_string(&full_path)
+                .with_context(|| format!("failed to read source of {full_path:?}"))?
+                .replace("\r\n", "\n"),
+        );
         Ok(SourceFile {
             tree_relative_path,
             code,
@@ -58,6 +63,10 @@ impl SourceFile {
 
     pub fn path(&self) -> &Utf8Path {
         self.tree_relative_path.as_path()
+    }
+
+    pub fn code(&self) -> &str {
+        self.code.as_str()
     }
 }
 
@@ -89,6 +98,6 @@ mod test {
             }),
         )
         .unwrap();
-        assert_eq!(source_file.code, "fn main() {\n    640 << 10;\n}\n");
+        assert_eq!(source_file.code(), "fn main() {\n    640 << 10;\n}\n");
     }
 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -31,7 +31,7 @@ pub struct SourceFile {
     ///
     /// This is held in an [Arc] so that SourceFiles can be cloned without using excessive
     /// amounts of memory.
-    code: Arc<String>,
+    pub code: Arc<String>,
 }
 
 impl SourceFile {

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -204,7 +204,7 @@ impl<'o> DiscoveryVisitor<'o> {
                     // The original block has braces and the replacements don't, so put
                     // them back for the comparison...
                     let new_block = quote!( { #rep } ).to_token_stream().to_pretty_string();
-                    dbg!(&orig_block, &new_block);
+                    // dbg!(&orig_block, &new_block);
                     if orig_block == new_block {
                         debug!("Replacement is the same as the function body; skipping");
                     } else {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -182,7 +182,7 @@ impl Workspace {
     }
 
     /// Find all the top source files for selected packages.
-    fn top_sources(&self, package_filter: &PackageFilter) -> Result<Vec<Arc<SourceFile>>> {
+    fn top_sources(&self, package_filter: &PackageFilter) -> Result<Vec<SourceFile>> {
         let mut sources = Vec::new();
         for PackageTop {
             package,
@@ -190,11 +190,11 @@ impl Workspace {
         } in self.package_tops(package_filter)?
         {
             for source_path in top_sources {
-                sources.push(Arc::new(SourceFile::new(
+                sources.push(SourceFile::new(
                     &self.dir,
                     source_path.to_owned(),
                     &package,
-                )?));
+                )?);
             }
         }
         Ok(sources)

--- a/tests/cli/snapshots/cli__list_mutants_in_all_trees_as_json.snap
+++ b/tests/cli/snapshots/cli__list_mutants_in_all_trees_as_json.snap
@@ -2458,36 +2458,6 @@ expression: buf
     },
     "genre": "FnValue",
     "package": "cargo-mutants-testdata-unapply",
-    "replacement": "1",
-    "span": {
-      "end": {
-        "column": 6,
-        "line": 2
-      },
-      "start": {
-        "column": 5,
-        "line": 2
-      }
-    }
-  },
-  {
-    "file": "src/a.rs",
-    "function": {
-      "function_name": "one",
-      "return_type": "-> i32",
-      "span": {
-        "end": {
-          "column": 2,
-          "line": 3
-        },
-        "start": {
-          "column": 1,
-          "line": 1
-        }
-      }
-    },
-    "genre": "FnValue",
-    "package": "cargo-mutants-testdata-unapply",
     "replacement": "-1",
     "span": {
       "end": {
@@ -2548,36 +2518,6 @@ expression: buf
     },
     "genre": "FnValue",
     "package": "cargo-mutants-testdata-unapply",
-    "replacement": "1",
-    "span": {
-      "end": {
-        "column": 6,
-        "line": 2
-      },
-      "start": {
-        "column": 5,
-        "line": 2
-      }
-    }
-  },
-  {
-    "file": "src/b.rs",
-    "function": {
-      "function_name": "one_untested",
-      "return_type": "-> i32",
-      "span": {
-        "end": {
-          "column": 2,
-          "line": 3
-        },
-        "start": {
-          "column": 1,
-          "line": 1
-        }
-      }
-    },
-    "genre": "FnValue",
-    "package": "cargo-mutants-testdata-unapply",
     "replacement": "-1",
     "span": {
       "end": {
@@ -2609,36 +2549,6 @@ expression: buf
     "genre": "FnValue",
     "package": "cargo-mutants-testdata-unapply",
     "replacement": "0",
-    "span": {
-      "end": {
-        "column": 6,
-        "line": 2
-      },
-      "start": {
-        "column": 5,
-        "line": 2
-      }
-    }
-  },
-  {
-    "file": "src/c.rs",
-    "function": {
-      "function_name": "one",
-      "return_type": "-> i32",
-      "span": {
-        "end": {
-          "column": 2,
-          "line": 3
-        },
-        "start": {
-          "column": 1,
-          "line": 1
-        }
-      }
-    },
-    "genre": "FnValue",
-    "package": "cargo-mutants-testdata-unapply",
-    "replacement": "1",
     "span": {
       "end": {
         "column": 6,

--- a/tests/cli/snapshots/cli__list_mutants_in_all_trees_as_text.snap
+++ b/tests/cli/snapshots/cli__list_mutants_in_all_trees_as_text.snap
@@ -234,13 +234,10 @@ src/lib.rs:6:5: replace try_value_coercion -> String with "xyzzy".into()
 
 ```
 src/a.rs:2:5: replace one -> i32 with 0
-src/a.rs:2:5: replace one -> i32 with 1
 src/a.rs:2:5: replace one -> i32 with -1
 src/b.rs:2:5: replace one_untested -> i32 with 0
-src/b.rs:2:5: replace one_untested -> i32 with 1
 src/b.rs:2:5: replace one_untested -> i32 with -1
 src/c.rs:2:5: replace one -> i32 with 0
-src/c.rs:2:5: replace one -> i32 with 1
 src/c.rs:2:5: replace one -> i32 with -1
 ```
 

--- a/tests/cli/snapshots/cli__mutants_are_unapplied_after_testing_so_later_missed_mutants_are_found.snap
+++ b/tests/cli/snapshots/cli__mutants_are_unapplied_after_testing_so_later_missed_mutants_are_found.snap
@@ -2,12 +2,9 @@
 source: tests/cli/main.rs
 expression: stdout
 ---
-Found 9 mutants to test
+Found 6 mutants to test
 Unmutated baseline ... ok
-src/a.rs:2:5: replace one -> i32 with 1 ... NOT CAUGHT
 src/b.rs:2:5: replace one_untested -> i32 with 0 ... NOT CAUGHT
-src/b.rs:2:5: replace one_untested -> i32 with 1 ... NOT CAUGHT
 src/b.rs:2:5: replace one_untested -> i32 with -1 ... NOT CAUGHT
-src/c.rs:2:5: replace one -> i32 with 1 ... NOT CAUGHT
-9 mutants tested: 5 missed, 4 caught
+6 mutants tested: 2 missed, 4 caught
 


### PR DESCRIPTION
For FnValue mutants: if the replacement has the same tokens as the original source, don't omit it, it can't find anything useful.

Fixes #134 