### PR TITLE
Changed ::= CD:  apply taiki-e/install-action@v2 to install ``mdbook``

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -28,10 +28,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install mdbook
-        run: |
-          mkdir mdbook
-          curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.21/mdbook-v0.4.21-x86_64-unknown-linux-gnu.tar.gz | tar -xz --directory=./mdbook
-          echo `pwd`/mdbook >> $GITHUB_PATH
+        uses: taiki-e/install-action@v2
+        with:
+          tool: mdbook
       - name: Setup Pages
         uses: actions/configure-pages@v2
       - name: Build book


### PR DESCRIPTION
This PR introduces the changes discussed in #202.

I replaced the current installation instructions for the `mdbook` binary with a call to https://github.com/taiki-e/install-action.  This Action is known to work without any problems in several other repositories, such as https://github.com/kevinmatthes/aeruginous-rs, for instance.

As I did not find any recommendations for commit messages, I applied the style I use in my projects for the automatic CHANGELOG generation.