### PR TITLE
Don't error if in-diff contains multiple deletions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # cargo-mutants changelog
 
+## Unreleased
+
+- Fixed: Fixed spurious "Patch input contains repeated filenames" error when `--in-diff` is given a patch that deletes multiple files.
+
 ## 23.12.2
 
 - New: A `--shard k/n` allows you to split the work across n independent parallel `cargo mutants` invocations running on separate machines to get a faster overall solution on large suites. You, or your CI system, are responsible for launching all the shards and checking whether any of them failed.

--- a/src/in_diff.rs
+++ b/src/in_diff.rs
@@ -25,6 +25,10 @@ pub fn diff_filter(mutants: Vec<Mutant>, diff_text: &str) -> Result<Vec<Mutant>>
     let mut lines_changed_by_path: HashMap<&Utf8Path, Vec<usize>> = HashMap::new();
     for patch in &patches {
         let path = strip_patch_path(&patch.new.path);
+        if path == "/dev/null" {
+            // The file was deleted; we can't possibly match anything in it.
+            continue;
+        }
         if lines_changed_by_path
             .insert(path, affected_lines(patch))
             .is_some()

--- a/src/snapshots/cargo_mutants__visit__test__expected_mutants_for_own_source_tree.snap
+++ b/src/snapshots/cargo_mutants__visit__test__expected_mutants_for_own_source_tree.snap
@@ -181,6 +181,7 @@ src/fnvalue.rs: replace == with != in match_first_type_arg
 src/in_diff.rs: replace diff_filter -> Result<Vec<Mutant>> with Ok(vec![])
 src/in_diff.rs: replace diff_filter -> Result<Vec<Mutant>> with Ok(vec![Default::default()])
 src/in_diff.rs: replace diff_filter -> Result<Vec<Mutant>> with Err(::anyhow::anyhow!("mutated!"))
+src/in_diff.rs: replace == with != in diff_filter
 src/in_diff.rs: replace check_diff_new_text_matches -> Result<()> with Ok(())
 src/in_diff.rs: replace check_diff_new_text_matches -> Result<()> with Err(::anyhow::anyhow!("mutated!"))
 src/in_diff.rs: replace != with == in check_diff_new_text_matches


### PR DESCRIPTION
Fixes `Error: Patch input contains repeated filename: "/dev/null"` #219