### PR TITLE
Fixed ::= CD:  do not attempt to deploy the book in forks

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   deploy:
+    if: github.repository == 'sourcefrog/cargo-mutants'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
This PR suggests a small bugfix in order to prevent the book deployment workflow being executed unnecessarily in forks of this repository.  I use this strategy for my repositories, as well, and it works fine.  There is also a [GitHub documentation page](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-run-job-for-specific-repository) about this topic.