### PR TITLE
Run book and tests workflows only on relevant PRs

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -5,6 +5,12 @@ on:
       - main
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/book.yml
+      - book/**
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -12,17 +18,39 @@ permissions:
   pages: write
   id-token: write
 
-# Allow one concurrent deployment
-concurrency:
-  group: "pages"
-  cancel-in-progress: true
-
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: beta
+      - uses: Swatinem/rust-cache@v2
+      - name: Install mdbook and mdbook-linkcheck
+        uses: taiki-e/install-action@v2
+        with:
+          tool: mdbook, mdbook-linkcheck
+      - name: Build mdbook
+        run: |
+          mdbook build book
+      - name: Archive book output
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: book
+          path: book/book
+
   deploy:
-    if: github.repository == 'sourcefrog/cargo-mutants'
+    if:
+      github.repository == 'sourcefrog/cargo-mutants' && github.ref_name ==
+      'main'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    concurrency: # Allow one concurrent deployment
+      group: "pages"
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,4 +1,4 @@
-name: Deploy book
+name: Book
 on:
   push:
     branches:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -145,25 +145,3 @@ jobs:
         with:
           name: mutants.out
           path: mutants.out
-
-  book:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: beta
-      - uses: Swatinem/rust-cache@v2
-      - name: Install mdbook and mdbook-linkcheck
-        uses: taiki-e/install-action@v2
-        with:
-          tool: mdbook, mdbook-linkcheck
-      - name: Build mdbook
-        run: |
-          mdbook build book
-      - name: Archive book output
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: book
-          path: book/book

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,14 @@ on:
     branches:
       - main
   pull_request:
+    paths:
+      - ".cargo/**"
+      - ".github/workflows/tests.yml"
+      - "Cargo.*"
+      - "mutants_attrs/**"
+      - "src/**"
+      - "testdata/**"
+      - "tests/**"
 
 # see https://matklad.github.io/2021/09/04/fast-rust-builds.html
 env:


### PR DESCRIPTION
The mutants tests are getting time consuming and there's no need to run
them on every change to the book