### PR TITLE
Fix progress bar for long copies

### DIFF
--- a/src/console.rs
+++ b/src/console.rs
@@ -555,7 +555,6 @@ impl CopyModel {
     /// Update that some bytes have been copied.
     ///
     /// `bytes_copied` is the total bytes copied so far.
-    #[allow(dead_code)]
     fn bytes_copied(&mut self, bytes_copied: u64) {
         self.bytes_copied = bytes_copied
     }

--- a/src/copy_tree.rs
+++ b/src/copy_tree.rs
@@ -80,7 +80,7 @@ pub fn copy_tree(
             })?;
             total_bytes += bytes_copied;
             total_files += 1;
-            console.copy_progress(bytes_copied);
+            console.copy_progress(total_bytes);
         } else if ft.is_dir() {
             std::fs::create_dir_all(&dest_path)
                 .with_context(|| format!("Failed to create directory {dest_path:?}"))?;


### PR DESCRIPTION
Fixes #227

The progress bar still resets when we copy multiple trees one after the other, but that's less bad.