### PR TITLE
Don't run all mutants in nextest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,7 +125,7 @@ jobs:
     strategy:
       matrix:
         shard: [0, 1, 2, 3, 4, 5, 6, 7]
-        test_tool: [cargo, nextest]
+        test_tool: [cargo] # or nextest, but normally disabled
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master


### PR DESCRIPTION
It's slower on this tree, and redundant with the main cargo test, and uses a fair bit of CPU.

After giving nextest support a while to bake, let's run it only for PR-mutants, not for the full run.