### PR TITLE
Try to make symlink testdata more robust

### DIFF
--- a/testdata/symlink/src/lib.rs
+++ b/testdata/symlink/src/lib.rs
@@ -1,15 +1,7 @@
 use std::path::Path;
 
-fn read_through_symlink() -> String {
+pub fn read_through_symlink() -> String {
     let path = Path::new("testdata/symlink");
     assert!(path.is_symlink());
     std::fs::read_to_string(path).unwrap()
-}
-
-#[cfg(test)]
-mod test {
-    #[test]
-    fn read_through_symlink_test() {
-        assert_eq!(super::read_through_symlink().trim(), "Hello, world!");
-    }
 }

--- a/testdata/symlink/tests/main.rs
+++ b/testdata/symlink/tests/main.rs
@@ -1,0 +1,22 @@
+use std::fs::{read_link, read_to_string};
+use std::path::Path;
+
+use cargo_mutants_testdata_symlink::read_through_symlink;
+
+#[test]
+fn read_through_symlink_test() {
+    assert_eq!(read_through_symlink().trim(), "Hello, world!");
+}
+
+/// This should fail from the baseline test if the symlink is somehow
+/// missing.
+#[test]
+fn symlink_testdata_exists() {
+    let target = Path::new("testdata/target");
+    let symlink = Path::new("testdata/symlink");
+    assert!(symlink.is_symlink());
+    assert!(target.is_file());
+    assert_eq!(read_link(&symlink).unwrap(), Path::new("target"));
+    assert_eq!(read_to_string(&target).unwrap().trim(), "Hello, world!");
+    assert_eq!(read_to_string(&symlink).unwrap().trim(), "Hello, world!");
+}


### PR DESCRIPTION
The `symlink` test failed on macOS for no obvious reason in <https://github.com/sourcefrog/cargo-mutants/actions/runs/7534161300>: perhaps some kind of lower-level race. This might make it more robust...