### PR TITLE
Only run tests on pushes that could affect the results

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,10 +4,20 @@ permissions:
   contents: read
 
 on:
+  pull_request:
+    paths:
+      - ".cargo/*.toml"
+      - ".github/workflows/tests.yml"
+      - "Cargo.*"
+      - "mutants_attrs/**"
+      - "src/**"
+      - "testdata/**"
+      - "tests/**"
+
   push:
     branches:
       - main
-  pull_request:
+    # Actions doesn't support YAML references, so it's repeated here
     paths:
       - ".cargo/*.toml"
       - ".github/workflows/tests.yml"


### PR DESCRIPTION
Changes to e.g. the book or readme shouldn't cause tests to fail, so we don't need to block on them.