### PR TITLE
Test Timeout Multiplier Flag

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 - Changed: Set `INSTA_FORCE_PASS=0` (in addition to previously `INSTA_UPDATE=no`) when running tests, so that tests that use the [Insta](https://insta.rs/) library don't write updates back into the source directory, and so don't falsely pass.
 
+- New: `--timeout-multiplier` option allows setting the timeout for mutants to be a multiple of the baseline timeout, rather than a fixed time.
+
 ## 24.2.0
 
 - New: Colored output can be enabled in CI or other noninteractive situations by passing `--colors=always`, or setting `CARGO_TERM_COLOR=always`, or `CLICOLOR_FORCE=1`. Colors can similarly be forced off with `--colors=never`, `CARGO_TERM_COLOR=never`, or `NO_COLOR=1`.

--- a/book/src/timeouts.md
+++ b/book/src/timeouts.md
@@ -31,6 +31,6 @@ You can also set an explicit timeout with the `--timeout` option, also measured
 in seconds. If this option is specified then the timeout is also applied to the
 unmutated tests.
 
-You can set a timeout multiplier that is relative to the duration of the unmutated tests with `--timeout-multiplier`. This option is only applied if the baseline is not skipped and no `--timeout` option is specified, otherwise it is ignored.
+You can set a timeout multiplier that is relative to the duration of the unmutated tests with `--timeout-multiplier` or setting `timeout_multiplier` in `.cargo/mutants.toml` (`timeout-multiplier = 1.5`). This option is only applied if the baseline is not skipped and no `--timeout` option is specified, otherwise it is ignored.
 
 The timeout does not apply to `cargo check` or `cargo build`, only `cargo test`.

--- a/book/src/timeouts.md
+++ b/book/src/timeouts.md
@@ -31,4 +31,6 @@ You can also set an explicit timeout with the `--timeout` option, also measured
 in seconds. If this option is specified then the timeout is also applied to the
 unmutated tests.
 
+You can set a timeout multiplier that is relative to the duration of the unmutated tests with `--timeout-multiplier`. This option is only applied if the baseline is not skipped and no `--timeout` option is specified, otherwise it is ignored.
+
 The timeout does not apply to `cargo check` or `cargo build`, only `cargo test`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,6 +44,8 @@ pub struct Config {
     pub minimum_test_timeout: Option<f64>,
     /// Choice of test tool: cargo or nextest.
     pub test_tool: Option<TestTool>,
+    /// Timeout multiplier, relative to the baseline 'cargo test'.
+    pub timeout_multiplier: Option<f64>,
 }
 
 impl Config {

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -173,11 +173,12 @@ fn test_timeout(baseline_outcome: &Option<ScenarioOutcome>, options: &Options) -
             options.minimum_test_timeout,
             Duration::from_secs(
                 (baseline_outcome
-                .as_ref()
-                .expect("Baseline tests should have run")
-                .total_phase_duration(Phase::Test)
-                .as_secs() as f64 // round
-                *options.test_timeout_multiplier.unwrap_or(5.0)) as u64,
+                    .as_ref()
+                    .expect("Baseline tests should have run")
+                    .total_phase_duration(Phase::Test)
+                    .as_secs_f64()
+                    * options.test_timeout_multiplier.unwrap_or(5.0))
+                .round() as u64,
             ),
         );
         if options.show_times {

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -180,10 +180,12 @@ fn test_timeout(baseline_outcome: &Option<ScenarioOutcome>, options: &Options) -
                 *options.test_timeout_multiplier.unwrap_or(5.0)) as u64,
             ),
         );
-        info!(
-            "Auto-set test timeout to {}",
-            humantime::format_duration(timeout)
-        );
+        if options.show_times {
+            info!(
+                "Auto-set test timeout to {}",
+                humantime::format_duration(timeout)
+            );
+        }
         timeout
     }
 }

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -168,6 +168,23 @@ fn test_timeout(baseline_outcome: &Option<ScenarioOutcome>, options: &Options) -
     } else if options.baseline == BaselineStrategy::Skip {
         warn!("An explicit timeout is recommended when using --baseline=skip; using 300 seconds by default");
         Duration::from_secs(300)
+    } else if let Some(multiplier) = options.test_timeout_multiplier {
+        let timeout = max(
+            options.minimum_test_timeout,
+            Duration::from_secs(
+                (baseline_outcome
+                .as_ref()
+                .expect("Baseline tests should have run")
+                .total_phase_duration(Phase::Test)
+                .as_secs() as f64 // round
+                *multiplier) as u64,
+            ),
+        );
+        info!(
+            "Set test timeout to {}",
+            humantime::format_duration(timeout)
+        );
+        timeout
     } else {
         let auto_timeout = max(
             options.minimum_test_timeout,

--- a/src/main.rs
+++ b/src/main.rs
@@ -285,6 +285,10 @@ pub struct Args {
     #[arg(long, short = 't', help_heading = "Execution")]
     timeout: Option<f64>,
 
+    /// test timeout multiplier (relative to base test time).
+    #[arg(long, help_heading = "Execution")]
+    timeout_multiplier: Option<f64>,
+
     /// print mutations that failed to check or build.
     #[arg(long, short = 'V', help_heading = "Output")]
     unviable: bool,

--- a/src/options.rs
+++ b/src/options.rs
@@ -214,7 +214,7 @@ impl Options {
             show_times: !args.no_times,
             show_all_logs: args.all_logs,
             test_timeout: args.timeout.map(Duration::from_secs_f64),
-            test_timeout_multiplier: args.timeout_multiplier,
+            test_timeout_multiplier: config.timeout_multiplier.or(args.timeout_multiplier),
             test_tool: args.test_tool.or(config.test_tool).unwrap_or_default(),
         };
         options.error_values.iter().for_each(|e| {

--- a/src/options.rs
+++ b/src/options.rs
@@ -44,6 +44,9 @@ pub struct Options {
     /// taken by the baseline test.
     pub test_timeout: Option<Duration>,
 
+    /// The time multiplier for test tasks, if set (relative to baseline test duration).
+    pub test_timeout_multiplier: Option<f64>,
+
     /// The minimum test timeout, as a floor on the autoset value.
     pub minimum_test_timeout: Duration,
 
@@ -211,6 +214,7 @@ impl Options {
             show_times: !args.no_times,
             show_all_logs: args.all_logs,
             test_timeout: args.timeout.map(Duration::from_secs_f64),
+            test_timeout_multiplier: args.timeout_multiplier,
             test_tool: args.test_tool.or(config.test_tool).unwrap_or_default(),
         };
         options.error_values.iter().for_each(|e| {


### PR DESCRIPTION
I've added a `--timeout-multiplier <f64>` flag that sets the test timeout to the baseline time multiplied by the f64 value of the flag. The incentive for doing this was the need for a variable time, not statically set with `--timeout`, but the original `5x` was too much. Please note that this commit was made on top of the latest release, and it is 8 commits behind the current `HEAD` of the `master` branch so we can use it before it is released on your repository. https://github.com/sourcefrog/cargo-mutants/discussions/276