### PR TITLE
fix(copy_tree): don't ignore files in `.ignore`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fixed: `.ignore` files can no longer affect source tree copying, so test files listed in a `.ignore` (e.g. `*.snap` for Insta snapshots) are now correctly copied into temporary build directories.
+
 ## 24.3.0
 
 - Fixed: `cargo install cargo-mutants` without `--locked` was failing due to breaking API changes in some unstable dependencies.

--- a/src/copy_tree.rs
+++ b/src/copy_tree.rs
@@ -50,6 +50,7 @@ pub fn copy_tree(
     for entry in WalkBuilder::new(from_path)
         .standard_filters(gitignore)
         .hidden(false)
+        .ignore(false)
         .require_git(false)
         .filter_entry(|entry| {
             !SOURCE_EXCLUDE.contains(&entry.file_name().to_string_lossy().as_ref())


### PR DESCRIPTION
In the end, this was about as easy as it gets, thanks to the lovely API of that `ignore` crate!

This still ignores all of the files ignored by git, but will now include those listed in `.ignore`. This allows files to be added to `.ignore` without breaking tests that might require those files. Fixes #321