### PR TITLE
Module path within nested `mod` blocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,7 @@ exclude = [
     "testdata/many_patterns",
     "testdata/missing_test",
     "testdata/mut_ref",
+    "testdata/nested_mod",
     "testdata/never_type",
     "testdata/override_dependency",
     "testdata/package-fails/",

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 - Fixed: Don't visit files marked with `#![cfg(test)]` (or other inner attributes that generally cause code to be skipped.)
 
+- Fixed: Paths to module files nested within `mod` blocks are now correctly resolved.
+
 - Document stability policy in the manual.
 
 ## 24.3.0

--- a/src/mutate.rs
+++ b/src/mutate.rs
@@ -57,7 +57,7 @@ pub struct Mutant {
 /// This is used for both mutations of the whole function, and smaller mutations within it.
 #[derive(Eq, PartialEq, Debug, Serialize)]
 pub struct Function {
-    /// The function that's being mutated.
+    /// The function that's being mutated, including any containing namespaces.
     pub function_name: String,
 
     /// The return type of the function, including a leading "-> ", as a fragment of Rust syntax.

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -354,9 +354,10 @@ impl<'ast> Visit<'ast> for DiscoveryVisitor<'_> {
         // statement referring to an external file. We remember the module
         // name and then later look for the file.
         if node.content.is_none() {
+            // If we're already inside `mod a { ... }` and see `mod b;` then
+            // remember [a, b] as an external module to visit later.
             let mut mod_namespace = self.namespace_stack.clone();
             mod_namespace.push(mod_name.to_owned());
-
             self.external_mods.push(mod_namespace);
         }
         self.in_namespace(mod_name, |v| syn::visit::visit_item_mod(v, node));

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -113,6 +113,7 @@ fn walk_file(
         error_exprs,
         external_mods: Vec::new(),
         mutants: Vec::new(),
+        mod_namespace_stack: Vec::new(),
         namespace_stack: Vec::new(),
         fn_stack: Vec::new(),
         source_file: source_file.clone(),
@@ -133,10 +134,26 @@ struct DiscoveryVisitor<'o> {
     /// The file being visited.
     source_file: SourceFile,
 
-    /// The stack of namespaces we're currently inside.
+    /// The stack of modules namespaces that we're currently inside, from
+    /// visiting `mod foo { ... }` statements.
+    ///
+    /// This is a subsequence of `namespace_stack`, containing only elements
+    /// that form a module path.
+    mod_namespace_stack: Vec<String>,
+
+    /// The stack of namespaces, loosely defined, that we're inside.
+    ///
+    /// Basically these are names or strings that can be concatenated with `::`
+    /// to form a name that meaningfully describes where we are; it might not
+    /// exactly be valid Rust.
+    ///
+    /// For example, this includes mods, fns, impls, etc.
     namespace_stack: Vec<String>,
 
     /// The functions we're inside.
+    ///
+    /// Empty at the top level, often has one element, but potentially more if
+    /// there are nested functions.
     fn_stack: Vec<Arc<Function>>,
 
     /// The names from `mod foo;` statements that should be visited later,
@@ -155,9 +172,9 @@ impl<'o> DiscoveryVisitor<'o> {
         span: proc_macro2::Span,
     ) -> Arc<Function> {
         self.namespace_stack.push(function_name.to_string());
-        let function_name = self.namespace_stack.join("::");
+        let full_function_name = self.namespace_stack.join("::");
         let function = Arc::new(Function {
-            function_name: function_name.to_owned(),
+            function_name: full_function_name,
             return_type: return_type.to_pretty_string(),
             span: span.into(),
         });
@@ -344,23 +361,23 @@ impl<'ast> Visit<'ast> for DiscoveryVisitor<'_> {
 
     /// Visit `mod foo { ... }` or `mod foo;`.
     fn visit_item_mod(&mut self, node: &'ast syn::ItemMod) {
-        let mod_name = &node.ident.unraw().to_string();
+        let mod_name = node.ident.unraw().to_string();
         let _span = trace_span!("mod", line = node.mod_token.span.start().line, mod_name).entered();
         if attrs_excluded(&node.attrs) {
             trace!("mod excluded by attrs");
             return;
         }
+        self.mod_namespace_stack.push(mod_name.clone());
         // If there's no content in braces, then this is a `mod foo;`
         // statement referring to an external file. We remember the module
         // name and then later look for the file.
         if node.content.is_none() {
             // If we're already inside `mod a { ... }` and see `mod b;` then
             // remember [a, b] as an external module to visit later.
-            let mut mod_namespace = self.namespace_stack.clone();
-            mod_namespace.push(mod_name.to_owned());
-            self.external_mods.push(mod_namespace);
+            self.external_mods.push(self.mod_namespace_stack.clone());
         }
-        self.in_namespace(mod_name, |v| syn::visit::visit_item_mod(v, node));
+        self.in_namespace(&mod_name, |v| syn::visit::visit_item_mod(v, node));
+        assert_eq!(self.mod_namespace_stack.pop(), Some(mod_name));
     }
 
     /// Visit `a op b` expressions.

--- a/testdata/nested_mod/Cargo.toml
+++ b/testdata/nested_mod/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "nested_mod"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]

--- a/testdata/nested_mod/Cargo.toml
+++ b/testdata/nested_mod/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
-name = "nested_mod"
+name = "cargo-mutants-testdata-nested-mod"
+publish = false
 version = "0.0.0"
 edition = "2021"
 

--- a/testdata/nested_mod/README.md
+++ b/testdata/nested_mod/README.md
@@ -1,0 +1,5 @@
+# `nested_mod` testdata tree
+
+This tree contains many nested modules from both toplevel files (lib.rs and main.rs) to exercise the module file discovery mechanism.
+
+The module names are descriptive where necessary (e.g. `c_file` is a file) and short where details are not needed (e.g. `a`, `b` for simple nesting).

--- a/testdata/nested_mod/src/block_in_lib/a/b/c_file.rs
+++ b/testdata/nested_mod/src/block_in_lib/a/b/c_file.rs
@@ -1,0 +1,5 @@
+pub mod d {
+    pub mod e {
+        pub mod f_file;
+    }
+}

--- a/testdata/nested_mod/src/block_in_lib/a/b/c_file/d/e/f_file.rs
+++ b/testdata/nested_mod/src/block_in_lib/a/b/c_file/d/e/f_file.rs
@@ -1,0 +1,3 @@
+pub fn always_true() -> bool {
+    true
+}

--- a/testdata/nested_mod/src/block_in_main/a/b/c_file.rs
+++ b/testdata/nested_mod/src/block_in_main/a/b/c_file.rs
@@ -1,0 +1,5 @@
+pub mod d {
+    pub mod e {
+        pub mod f_file;
+    }
+}

--- a/testdata/nested_mod/src/block_in_main/a/b/c_file/d/e/f_file.rs
+++ b/testdata/nested_mod/src/block_in_main/a/b/c_file/d/e/f_file.rs
@@ -1,0 +1,3 @@
+pub fn always_true() -> bool {
+    true
+}

--- a/testdata/nested_mod/src/file_in_lib.rs
+++ b/testdata/nested_mod/src/file_in_lib.rs
@@ -1,0 +1,5 @@
+pub mod a {
+    pub mod b {
+        pub mod c_file;
+    }
+}

--- a/testdata/nested_mod/src/file_in_lib/a/b/c_file.rs
+++ b/testdata/nested_mod/src/file_in_lib/a/b/c_file.rs
@@ -1,0 +1,5 @@
+pub mod d {
+    pub mod e {
+        pub mod f_file;
+    }
+}

--- a/testdata/nested_mod/src/file_in_lib/a/b/c_file/d/e/f_file.rs
+++ b/testdata/nested_mod/src/file_in_lib/a/b/c_file/d/e/f_file.rs
@@ -1,0 +1,3 @@
+pub fn always_true() -> bool {
+    true
+}

--- a/testdata/nested_mod/src/file_in_main.rs
+++ b/testdata/nested_mod/src/file_in_main.rs
@@ -1,0 +1,5 @@
+pub mod a {
+    pub mod b {
+        pub mod c_file;
+    }
+}

--- a/testdata/nested_mod/src/file_in_main/a/b/c_file.rs
+++ b/testdata/nested_mod/src/file_in_main/a/b/c_file.rs
@@ -1,0 +1,5 @@
+pub mod d {
+    pub mod e {
+        pub mod f_file;
+    }
+}

--- a/testdata/nested_mod/src/file_in_main/a/b/c_file/d/e/f_file.rs
+++ b/testdata/nested_mod/src/file_in_main/a/b/c_file/d/e/f_file.rs
@@ -1,0 +1,3 @@
+pub fn always_true() -> bool {
+    true
+}

--- a/testdata/nested_mod/src/lib.rs
+++ b/testdata/nested_mod/src/lib.rs
@@ -1,0 +1,18 @@
+pub mod block_in_lib {
+    pub mod a {
+        pub mod b {
+            pub mod c_file;
+        }
+    }
+}
+
+pub mod file_in_lib;
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert!(crate::file_in_lib::a::b::c_file::d::e::f_file::always_true());
+        assert!(crate::block_in_lib::a::b::c_file::d::e::f_file::always_true());
+    }
+}

--- a/testdata/nested_mod/src/main.rs
+++ b/testdata/nested_mod/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/testdata/nested_mod/src/main.rs
+++ b/testdata/nested_mod/src/main.rs
@@ -1,3 +1,20 @@
-fn main() {
-    println!("Hello, world!");
+fn main() {}
+
+pub mod block_in_main {
+    pub mod a {
+        pub mod b {
+            pub mod c_file;
+        }
+    }
+}
+
+pub mod file_in_main;
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert!(crate::file_in_main::a::b::c_file::d::e::f_file::always_true());
+        assert!(crate::block_in_main::a::b::c_file::d::e::f_file::always_true());
+    }
 }

--- a/tests/snapshots/list__list_mutants_in_all_trees_as_json.snap
+++ b/tests/snapshots/list__list_mutants_in_all_trees_as_json.snap
@@ -3366,7 +3366,128 @@ expression: buf
 ## testdata/nested_mod
 
 ```json
-[]
+[
+  {
+    "file": "src/block_in_lib/a/b/c_file/d/e/f_file.rs",
+    "function": {
+      "function_name": "always_true",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 3
+        },
+        "start": {
+          "column": 1,
+          "line": 1
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "nested_mod",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 9,
+        "line": 2
+      },
+      "start": {
+        "column": 5,
+        "line": 2
+      }
+    }
+  },
+  {
+    "file": "src/block_in_main/a/b/c_file/d/e/f_file.rs",
+    "function": {
+      "function_name": "always_true",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 3
+        },
+        "start": {
+          "column": 1,
+          "line": 1
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "nested_mod",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 9,
+        "line": 2
+      },
+      "start": {
+        "column": 5,
+        "line": 2
+      }
+    }
+  },
+  {
+    "file": "src/file_in_lib/a/b/c_file/d/e/f_file.rs",
+    "function": {
+      "function_name": "always_true",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 3
+        },
+        "start": {
+          "column": 1,
+          "line": 1
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "nested_mod",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 9,
+        "line": 2
+      },
+      "start": {
+        "column": 5,
+        "line": 2
+      }
+    }
+  },
+  {
+    "file": "src/file_in_main/a/b/c_file/d/e/f_file.rs",
+    "function": {
+      "function_name": "always_true",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 3
+        },
+        "start": {
+          "column": 1,
+          "line": 1
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "nested_mod",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 9,
+        "line": 2
+      },
+      "start": {
+        "column": 5,
+        "line": 2
+      }
+    }
+  }
+]
 ```
 
 ## testdata/never_type

--- a/tests/snapshots/list__list_mutants_in_all_trees_as_json.snap
+++ b/tests/snapshots/list__list_mutants_in_all_trees_as_json.snap
@@ -3363,6 +3363,12 @@ expression: buf
 ]
 ```
 
+## testdata/nested_mod
+
+```json
+[]
+```
+
 ## testdata/never_type
 
 ```json

--- a/tests/snapshots/list__list_mutants_in_all_trees_as_json.snap
+++ b/tests/snapshots/list__list_mutants_in_all_trees_as_json.snap
@@ -3384,7 +3384,7 @@ expression: buf
       }
     },
     "genre": "FnValue",
-    "package": "nested_mod",
+    "package": "cargo-mutants-testdata-nested-mod",
     "replacement": "false",
     "span": {
       "end": {
@@ -3414,7 +3414,7 @@ expression: buf
       }
     },
     "genre": "FnValue",
-    "package": "nested_mod",
+    "package": "cargo-mutants-testdata-nested-mod",
     "replacement": "false",
     "span": {
       "end": {
@@ -3444,7 +3444,7 @@ expression: buf
       }
     },
     "genre": "FnValue",
-    "package": "nested_mod",
+    "package": "cargo-mutants-testdata-nested-mod",
     "replacement": "false",
     "span": {
       "end": {
@@ -3474,7 +3474,7 @@ expression: buf
       }
     },
     "genre": "FnValue",
-    "package": "nested_mod",
+    "package": "cargo-mutants-testdata-nested-mod",
     "replacement": "false",
     "span": {
       "end": {

--- a/tests/snapshots/list__list_mutants_in_all_trees_as_text.snap
+++ b/tests/snapshots/list__list_mutants_in_all_trees_as_text.snap
@@ -219,6 +219,11 @@ src/lib.rs:2:5: replace returns_mut_ref -> &mut u32 with Box::leak(Box::new(0))
 src/lib.rs:2:5: replace returns_mut_ref -> &mut u32 with Box::leak(Box::new(1))
 ```
 
+## testdata/nested_mod
+
+```
+```
+
 ## testdata/never_type
 
 ```

--- a/tests/snapshots/list__list_mutants_in_all_trees_as_text.snap
+++ b/tests/snapshots/list__list_mutants_in_all_trees_as_text.snap
@@ -222,6 +222,10 @@ src/lib.rs:2:5: replace returns_mut_ref -> &mut u32 with Box::leak(Box::new(1))
 ## testdata/nested_mod
 
 ```
+src/block_in_lib/a/b/c_file/d/e/f_file.rs:2:5: replace always_true -> bool with false
+src/block_in_main/a/b/c_file/d/e/f_file.rs:2:5: replace always_true -> bool with false
+src/file_in_lib/a/b/c_file/d/e/f_file.rs:2:5: replace always_true -> bool with false
+src/file_in_main/a/b/c_file/d/e/f_file.rs:2:5: replace always_true -> bool with false
 ```
 
 ## testdata/never_type


### PR DESCRIPTION
Following on discussion in #327, to add the `mod` block namespace to the module file path.

## Tasks:

* [x]  Copy the tree under `testdata/nested_mod` and package name  (with mixed levels of nesting of blocks and files)
* [x]  Add `nested_mod` to the workspace exclusions in `/Cargo.toml`
* [x]  Add the namespaces to the stack in `visit.rs`
* [ ]  Add a test in `visit.rs` for reading the testdata, like in https://github.com/sourcefrog/cargo-mutants/blob/442412650fc9770f3bc84467e1b104f5ef51b7a6/src/visit.rs#L589-L599

---

I haven't yet added the unit test inside `visit.rs`.   It seems like the functionality (finding the module) is automatically verified by the `cargo-insta` tests (plaintext and json).

Do you think it would still be helpful to add a test inside `visit.rs`?