### PR TITLE
Follow `path` attribute on inline `mod` blocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,7 @@ exclude = [
     "testdata/cfg_attr_test_skip",
     "testdata/cfg_test_inner",
     "testdata/custom_top_file",
+    "testdata/dangling_mod",
     "testdata/dependency",
     "testdata/diff0",
     "testdata/diff1",

--- a/src/path.rs
+++ b/src/path.rs
@@ -7,7 +7,7 @@ use camino::Utf8Path;
 /// Measures how far above its starting point a path ascends.
 ///
 /// If in following this path you would ever ascend above the starting point,
-/// this returns a whole number indicating the number of steps above the
+/// this returns a positive number indicating the number of steps above the
 /// starting point.
 ///
 /// This only considers the textual content of the path, and does not look at

--- a/src/source.rs
+++ b/src/source.rs
@@ -11,6 +11,7 @@ use tracing::{debug, info, warn};
 
 use crate::package::Package;
 use crate::path::Utf8PathSlashes;
+use crate::span::LineColumn;
 
 /// A Rust source file within a source tree.
 ///
@@ -73,6 +74,13 @@ impl SourceFile {
 
     pub fn code(&self) -> &str {
         self.code.as_str()
+    }
+
+    /// Format a location within this source file for display to the user
+    pub fn format_source_location(&self, location: LineColumn) -> String {
+        let source_file = self.tree_relative_slashes();
+        let LineColumn { line, column } = location;
+        format!("{source_file}:{line}:{column}")
     }
 }
 

--- a/src/source.rs
+++ b/src/source.rs
@@ -50,7 +50,10 @@ impl SourceFile {
         is_top: bool,
     ) -> Result<Option<SourceFile>> {
         if ascent(&tree_relative_path) > 0 {
-            warn!("skipping source outside of tree: {tree_relative_path:?}");
+            warn!(
+                "skipping source outside of tree: {:?}",
+                tree_relative_path.to_slash_path()
+            );
             return Ok(None);
         }
         let full_path = tree_path.join(&tree_relative_path);

--- a/src/source.rs
+++ b/src/source.rs
@@ -10,7 +10,7 @@ use camino::{Utf8Path, Utf8PathBuf};
 use tracing::{debug, info, warn};
 
 use crate::package::Package;
-use crate::path::Utf8PathSlashes;
+use crate::path::{ascent, Utf8PathSlashes};
 use crate::span::LineColumn;
 
 /// A Rust source file within a source tree.
@@ -48,19 +48,23 @@ impl SourceFile {
         tree_relative_path: Utf8PathBuf,
         package: &Arc<Package>,
         is_top: bool,
-    ) -> Result<SourceFile> {
+    ) -> Result<Option<SourceFile>> {
+        if ascent(&tree_relative_path) > 0 {
+            warn!("skipping source outside of tree: {tree_relative_path:?}");
+            return Ok(None);
+        }
         let full_path = tree_path.join(&tree_relative_path);
         let code = Arc::new(
             std::fs::read_to_string(&full_path)
                 .with_context(|| format!("failed to read source of {full_path:?}"))?
                 .replace("\r\n", "\n"),
         );
-        Ok(SourceFile {
+        Ok(Some(SourceFile {
             tree_relative_path,
             code,
             package: Arc::clone(package),
             is_top,
-        })
+        }))
     }
 
     /// Return the path of this file relative to the tree root, with forward slashes.
@@ -112,7 +116,23 @@ mod test {
             }),
             true,
         )
+        .unwrap()
         .unwrap();
         assert_eq!(source_file.code(), "fn main() {\n    640 << 10;\n}\n");
+    }
+
+    #[test]
+    fn skips_files_outside_of_workspace() {
+        let source_file = SourceFile::new(
+            &Utf8PathBuf::from("unimportant"),
+            "../outside_workspace.rs".parse().unwrap(),
+            &Arc::new(Package {
+                name: "imaginary-package".to_owned(),
+                relative_manifest_path: "whatever/Cargo.toml".into(),
+            }),
+            true,
+        )
+        .unwrap();
+        assert_eq!(source_file, None);
     }
 }

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -190,7 +190,7 @@ impl Workspace {
         } in self.package_tops(package_filter)?
         {
             for source_path in top_sources {
-                sources.push(SourceFile::new(
+                sources.extend(SourceFile::new(
                     &self.dir,
                     source_path.to_owned(),
                     &package,

--- a/testdata/dangling_mod/Cargo.toml
+++ b/testdata/dangling_mod/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "cargo-mutants-testdata-dangling-mod"
+publish = false
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]

--- a/testdata/dangling_mod/README.md
+++ b/testdata/dangling_mod/README.md
@@ -1,0 +1,8 @@
+# `dangling_mod` testdata tree
+
+This tree intentionally omits a module file to verify the discovery system continues gracefully in the face of module file warnings.
+
+Notes:
+- `#[cfg(not(test))]` allows tests to run despite the intentionally missing module file
+- `lib.rs` is omitted, as the `#[cfg(not(test))]` trick does not work for the `cargo build` step in `cargo-mutants`
+

--- a/testdata/dangling_mod/README.md
+++ b/testdata/dangling_mod/README.md
@@ -1,6 +1,8 @@
 # `dangling_mod` testdata tree
 
-This tree intentionally omits a module file to verify the discovery system continues gracefully in the face of module file warnings.
+This tree intentionally references invalid module files to verify the discovery system continues gracefully in the face of module file warnings.
+1. `nonexistent` - the source file does not exist
+2. `outside_of_workspace` - the source file exists outside of the workspace (and is accepted by rustc) but is outside the scope of `cargo-mutants` to apply modifications
 
 Notes:
 - `#[cfg(not(test))]` allows tests to run despite the intentionally missing module file

--- a/testdata/dangling_mod/src/main.rs
+++ b/testdata/dangling_mod/src/main.rs
@@ -4,6 +4,10 @@ fn main() {}
 #[cfg(not(test))] // allow tests to run successfully
 mod nonexistent;
 
+#[path = "../../nested_mod/src/paths_in_main/a/foo.rs"]
+#[cfg(not(test))] // allow tests to run successfully
+pub mod outside_workspace;
+
 mod verify_continue {
     pub fn always_true() -> bool {
         true

--- a/testdata/dangling_mod/src/main.rs
+++ b/testdata/dangling_mod/src/main.rs
@@ -1,0 +1,19 @@
+fn main() {}
+
+/// Source file intentionally does not exist
+#[cfg(not(test))] // allow tests to run successfully
+mod nonexistent;
+
+mod verify_continue {
+    pub fn always_true() -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        assert!(super::verify_continue::always_true());
+    }
+}

--- a/testdata/nested_mod/src/lib.rs
+++ b/testdata/nested_mod/src/lib.rs
@@ -8,11 +8,49 @@ pub mod block_in_lib {
 
 pub mod file_in_lib;
 
+pub mod paths_in_lib {
+    //! Loosely follows naming from examples in the reference
+    //! <https://doc.rust-lang.org/reference/items/modules.html#the-path-attribute>
+
+    pub mod a {
+        pub mod b;
+    }
+    pub mod a_mod_file;
+
+    #[path = "thread_files"]
+    pub mod thread {
+        #[path = "tls.rs"]
+        pub mod local_data;
+    }
+
+    pub mod thread_inner_attr {
+        //! `path` can also be an inner attribute on `mod foo { ... }` blocks
+        #![path = "thread_files_inner_attr"]
+
+        #[path = "tls.rs"]
+        pub mod local_data;
+    }
+}
+
+#[path = "toplevel_file_in_lib.rs"]
+pub mod toplevel_in_lib;
+
 #[cfg(test)]
 mod tests {
     #[test]
     fn it_works() {
         assert!(crate::file_in_lib::a::b::c_file::d::e::f_file::always_true());
         assert!(crate::block_in_lib::a::b::c_file::d::e::f_file::always_true());
+
+        assert!(crate::paths_in_lib::a::b::c::always_true());
+        assert!(crate::paths_in_lib::a_mod_file::c::always_true());
+
+        assert!(crate::paths_in_lib::a::b::inline::inner::always_true());
+        assert!(crate::paths_in_lib::a_mod_file::inline::inner::always_true());
+
+        assert!(crate::paths_in_lib::thread::local_data::always_true());
+        assert!(crate::paths_in_lib::thread_inner_attr::local_data::always_true());
+
+        assert!(crate::toplevel_in_lib::always_true());
     }
 }

--- a/testdata/nested_mod/src/lib.rs
+++ b/testdata/nested_mod/src/lib.rs
@@ -30,6 +30,8 @@ pub mod paths_in_lib {
         #[path = "tls.rs"]
         pub mod local_data;
     }
+
+    pub mod upward_traversal;
 }
 
 #[path = "toplevel_file_in_lib.rs"]
@@ -50,6 +52,8 @@ mod tests {
 
         assert!(crate::paths_in_lib::thread::local_data::always_true());
         assert!(crate::paths_in_lib::thread_inner_attr::local_data::always_true());
+
+        assert!(crate::paths_in_lib::upward_traversal::target::always_true());
 
         assert!(crate::toplevel_in_lib::always_true());
     }

--- a/testdata/nested_mod/src/main.rs
+++ b/testdata/nested_mod/src/main.rs
@@ -10,11 +10,49 @@ pub mod block_in_main {
 
 pub mod file_in_main;
 
+pub mod paths_in_main {
+    //! Loosely follows naming from examples in the reference
+    //! <https://doc.rust-lang.org/reference/items/modules.html#the-path-attribute>
+
+    pub mod a {
+        pub mod b;
+    }
+    pub mod a_mod_file;
+
+    #[path = "thread_files"]
+    pub mod thread {
+        #[path = "tls.rs"]
+        pub mod local_data;
+    }
+
+    pub mod thread_inner_attr {
+        //! `path` can also be an inner attribute on `mod foo { ... }` blocks
+        #![path = "thread_files_inner_attr"]
+
+        #[path = "tls.rs"]
+        pub mod local_data;
+    }
+}
+
+#[path = "toplevel_file_in_main.rs"]
+pub mod toplevel_in_main;
+
 #[cfg(test)]
 mod tests {
     #[test]
     fn it_works() {
         assert!(crate::file_in_main::a::b::c_file::d::e::f_file::always_true());
         assert!(crate::block_in_main::a::b::c_file::d::e::f_file::always_true());
+
+        assert!(crate::paths_in_main::a::b::c::always_true());
+        assert!(crate::paths_in_main::a_mod_file::c::always_true());
+
+        assert!(crate::paths_in_main::a::b::inline::inner::always_true());
+        assert!(crate::paths_in_main::a_mod_file::inline::inner::always_true());
+
+        assert!(crate::paths_in_main::thread::local_data::always_true());
+        assert!(crate::paths_in_main::thread_inner_attr::local_data::always_true());
+
+        assert!(crate::toplevel_in_main::always_true());
     }
 }

--- a/testdata/nested_mod/src/paths_in_lib/a/b.rs
+++ b/testdata/nested_mod/src/paths_in_lib/a/b.rs
@@ -1,0 +1,7 @@
+#[path = "foo.rs"]
+pub mod c;
+
+pub mod inline {
+    #[path = "other.rs"]
+    pub mod inner;
+}

--- a/testdata/nested_mod/src/paths_in_lib/a/b/inline/other.rs
+++ b/testdata/nested_mod/src/paths_in_lib/a/b/inline/other.rs
@@ -1,0 +1,3 @@
+pub fn always_true() -> bool {
+    true
+}

--- a/testdata/nested_mod/src/paths_in_lib/a/foo.rs
+++ b/testdata/nested_mod/src/paths_in_lib/a/foo.rs
@@ -1,0 +1,3 @@
+pub fn always_true() -> bool {
+    true
+}

--- a/testdata/nested_mod/src/paths_in_lib/a_mod_file/foo.rs
+++ b/testdata/nested_mod/src/paths_in_lib/a_mod_file/foo.rs
@@ -1,0 +1,3 @@
+pub fn always_true() -> bool {
+    true
+}

--- a/testdata/nested_mod/src/paths_in_lib/a_mod_file/inline/other.rs
+++ b/testdata/nested_mod/src/paths_in_lib/a_mod_file/inline/other.rs
@@ -1,0 +1,3 @@
+pub fn always_true() -> bool {
+    true
+}

--- a/testdata/nested_mod/src/paths_in_lib/a_mod_file/mod.rs
+++ b/testdata/nested_mod/src/paths_in_lib/a_mod_file/mod.rs
@@ -1,0 +1,7 @@
+#[path = "foo.rs"]
+pub mod c;
+
+pub mod inline {
+    #[path = "other.rs"]
+    pub mod inner;
+}

--- a/testdata/nested_mod/src/paths_in_lib/thread_files/tls.rs
+++ b/testdata/nested_mod/src/paths_in_lib/thread_files/tls.rs
@@ -1,0 +1,3 @@
+pub fn always_true() -> bool {
+    true
+}

--- a/testdata/nested_mod/src/paths_in_lib/thread_files_inner_attr/tls.rs
+++ b/testdata/nested_mod/src/paths_in_lib/thread_files_inner_attr/tls.rs
@@ -1,0 +1,3 @@
+pub fn always_true() -> bool {
+    true
+}

--- a/testdata/nested_mod/src/paths_in_lib/upward_traversal.rs
+++ b/testdata/nested_mod/src/paths_in_lib/upward_traversal.rs
@@ -1,0 +1,2 @@
+#[path = "../upward_traversal_file_for_lib.rs"]
+pub mod target;

--- a/testdata/nested_mod/src/paths_in_main/a/b.rs
+++ b/testdata/nested_mod/src/paths_in_main/a/b.rs
@@ -1,0 +1,7 @@
+#[path = "foo.rs"]
+pub mod c;
+
+pub mod inline {
+    #[path = "other.rs"]
+    pub mod inner;
+}

--- a/testdata/nested_mod/src/paths_in_main/a/b/inline/other.rs
+++ b/testdata/nested_mod/src/paths_in_main/a/b/inline/other.rs
@@ -1,0 +1,3 @@
+pub fn always_true() -> bool {
+    true
+}

--- a/testdata/nested_mod/src/paths_in_main/a/foo.rs
+++ b/testdata/nested_mod/src/paths_in_main/a/foo.rs
@@ -1,0 +1,3 @@
+pub fn always_true() -> bool {
+    true
+}

--- a/testdata/nested_mod/src/paths_in_main/a_mod_file/foo.rs
+++ b/testdata/nested_mod/src/paths_in_main/a_mod_file/foo.rs
@@ -1,0 +1,3 @@
+pub fn always_true() -> bool {
+    true
+}

--- a/testdata/nested_mod/src/paths_in_main/a_mod_file/inline/other.rs
+++ b/testdata/nested_mod/src/paths_in_main/a_mod_file/inline/other.rs
@@ -1,0 +1,3 @@
+pub fn always_true() -> bool {
+    true
+}

--- a/testdata/nested_mod/src/paths_in_main/a_mod_file/mod.rs
+++ b/testdata/nested_mod/src/paths_in_main/a_mod_file/mod.rs
@@ -1,0 +1,7 @@
+#[path = "foo.rs"]
+pub mod c;
+
+pub mod inline {
+    #[path = "other.rs"]
+    pub mod inner;
+}

--- a/testdata/nested_mod/src/paths_in_main/thread_files/tls.rs
+++ b/testdata/nested_mod/src/paths_in_main/thread_files/tls.rs
@@ -1,0 +1,3 @@
+pub fn always_true() -> bool {
+    true
+}

--- a/testdata/nested_mod/src/paths_in_main/thread_files_inner_attr/tls.rs
+++ b/testdata/nested_mod/src/paths_in_main/thread_files_inner_attr/tls.rs
@@ -1,0 +1,3 @@
+pub fn always_true() -> bool {
+    true
+}

--- a/testdata/nested_mod/src/toplevel_file_in_lib.rs
+++ b/testdata/nested_mod/src/toplevel_file_in_lib.rs
@@ -1,0 +1,3 @@
+pub fn always_true() -> bool {
+    true
+}

--- a/testdata/nested_mod/src/toplevel_file_in_main.rs
+++ b/testdata/nested_mod/src/toplevel_file_in_main.rs
@@ -1,0 +1,3 @@
+pub fn always_true() -> bool {
+    true
+}

--- a/testdata/nested_mod/src/upward_traversal_file_for_lib.rs
+++ b/testdata/nested_mod/src/upward_traversal_file_for_lib.rs
@@ -1,0 +1,3 @@
+pub fn always_true() -> bool {
+    true
+}

--- a/tests/error_value.rs
+++ b/tests/error_value.rs
@@ -95,6 +95,21 @@ fn warn_if_error_value_starts_with_err() {
 }
 
 #[test]
+fn warn_unresolved_module() {
+    let tmp_src_dir = copy_of_testdata("dangling_mod");
+    run()
+        .arg("mutants")
+        .args(["--no-times", "--no-shuffle", "--no-config", "--list"])
+        .arg("-d")
+        .arg(tmp_src_dir.path())
+        .assert()
+        .code(0)
+        .stderr(predicate::str::contains(
+            r#"referent of mod not found definition_site="src/main.rs:5:1" mod_name=nonexistent"#,
+        ));
+}
+
+#[test]
 fn fail_when_error_value_does_not_parse() {
     let tmp_src_dir = copy_of_testdata("error_value");
     run()

--- a/tests/snapshots/list__list_mutants_in_all_trees_as_json.snap
+++ b/tests/snapshots/list__list_mutants_in_all_trees_as_json.snap
@@ -3368,6 +3368,186 @@ expression: buf
 ```json
 [
   {
+    "file": "src/paths_in_lib/thread_files/tls.rs",
+    "function": {
+      "function_name": "always_true",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 3
+        },
+        "start": {
+          "column": 1,
+          "line": 1
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-nested-mod",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 9,
+        "line": 2
+      },
+      "start": {
+        "column": 5,
+        "line": 2
+      }
+    }
+  },
+  {
+    "file": "src/paths_in_lib/thread_files_inner_attr/tls.rs",
+    "function": {
+      "function_name": "always_true",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 3
+        },
+        "start": {
+          "column": 1,
+          "line": 1
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-nested-mod",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 9,
+        "line": 2
+      },
+      "start": {
+        "column": 5,
+        "line": 2
+      }
+    }
+  },
+  {
+    "file": "src/toplevel_file_in_lib.rs",
+    "function": {
+      "function_name": "always_true",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 3
+        },
+        "start": {
+          "column": 1,
+          "line": 1
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-nested-mod",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 9,
+        "line": 2
+      },
+      "start": {
+        "column": 5,
+        "line": 2
+      }
+    }
+  },
+  {
+    "file": "src/paths_in_main/thread_files/tls.rs",
+    "function": {
+      "function_name": "always_true",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 3
+        },
+        "start": {
+          "column": 1,
+          "line": 1
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-nested-mod",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 9,
+        "line": 2
+      },
+      "start": {
+        "column": 5,
+        "line": 2
+      }
+    }
+  },
+  {
+    "file": "src/paths_in_main/thread_files_inner_attr/tls.rs",
+    "function": {
+      "function_name": "always_true",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 3
+        },
+        "start": {
+          "column": 1,
+          "line": 1
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-nested-mod",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 9,
+        "line": 2
+      },
+      "start": {
+        "column": 5,
+        "line": 2
+      }
+    }
+  },
+  {
+    "file": "src/toplevel_file_in_main.rs",
+    "function": {
+      "function_name": "always_true",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 3
+        },
+        "start": {
+          "column": 1,
+          "line": 1
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-nested-mod",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 9,
+        "line": 2
+      },
+      "start": {
+        "column": 5,
+        "line": 2
+      }
+    }
+  },
+  {
     "file": "src/block_in_lib/a/b/c_file/d/e/f_file.rs",
     "function": {
       "function_name": "always_true",
@@ -3398,7 +3578,247 @@ expression: buf
     }
   },
   {
+    "file": "src/paths_in_lib/a/foo.rs",
+    "function": {
+      "function_name": "always_true",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 3
+        },
+        "start": {
+          "column": 1,
+          "line": 1
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-nested-mod",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 9,
+        "line": 2
+      },
+      "start": {
+        "column": 5,
+        "line": 2
+      }
+    }
+  },
+  {
+    "file": "src/paths_in_lib/a/b/inline/other.rs",
+    "function": {
+      "function_name": "always_true",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 3
+        },
+        "start": {
+          "column": 1,
+          "line": 1
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-nested-mod",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 9,
+        "line": 2
+      },
+      "start": {
+        "column": 5,
+        "line": 2
+      }
+    }
+  },
+  {
+    "file": "src/paths_in_lib/a_mod_file/foo.rs",
+    "function": {
+      "function_name": "always_true",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 3
+        },
+        "start": {
+          "column": 1,
+          "line": 1
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-nested-mod",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 9,
+        "line": 2
+      },
+      "start": {
+        "column": 5,
+        "line": 2
+      }
+    }
+  },
+  {
+    "file": "src/paths_in_lib/a_mod_file/inline/other.rs",
+    "function": {
+      "function_name": "always_true",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 3
+        },
+        "start": {
+          "column": 1,
+          "line": 1
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-nested-mod",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 9,
+        "line": 2
+      },
+      "start": {
+        "column": 5,
+        "line": 2
+      }
+    }
+  },
+  {
     "file": "src/block_in_main/a/b/c_file/d/e/f_file.rs",
+    "function": {
+      "function_name": "always_true",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 3
+        },
+        "start": {
+          "column": 1,
+          "line": 1
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-nested-mod",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 9,
+        "line": 2
+      },
+      "start": {
+        "column": 5,
+        "line": 2
+      }
+    }
+  },
+  {
+    "file": "src/paths_in_main/a/foo.rs",
+    "function": {
+      "function_name": "always_true",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 3
+        },
+        "start": {
+          "column": 1,
+          "line": 1
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-nested-mod",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 9,
+        "line": 2
+      },
+      "start": {
+        "column": 5,
+        "line": 2
+      }
+    }
+  },
+  {
+    "file": "src/paths_in_main/a/b/inline/other.rs",
+    "function": {
+      "function_name": "always_true",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 3
+        },
+        "start": {
+          "column": 1,
+          "line": 1
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-nested-mod",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 9,
+        "line": 2
+      },
+      "start": {
+        "column": 5,
+        "line": 2
+      }
+    }
+  },
+  {
+    "file": "src/paths_in_main/a_mod_file/foo.rs",
+    "function": {
+      "function_name": "always_true",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 3
+        },
+        "start": {
+          "column": 1,
+          "line": 1
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-nested-mod",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 9,
+        "line": 2
+      },
+      "start": {
+        "column": 5,
+        "line": 2
+      }
+    }
+  },
+  {
+    "file": "src/paths_in_main/a_mod_file/inline/other.rs",
     "function": {
       "function_name": "always_true",
       "return_type": "-> bool",

--- a/tests/snapshots/list__list_mutants_in_all_trees_as_json.snap
+++ b/tests/snapshots/list__list_mutants_in_all_trees_as_json.snap
@@ -716,6 +716,43 @@ expression: buf
 ]
 ```
 
+## testdata/dangling_mod
+
+```json
+[
+  {
+    "file": "src/main.rs",
+    "function": {
+      "function_name": "verify_continue::always_true",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 6,
+          "line": 10
+        },
+        "start": {
+          "column": 5,
+          "line": 8
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-dangling-mod",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 13,
+        "line": 9
+      },
+      "start": {
+        "column": 9,
+        "line": 9
+      }
+    }
+  }
+]
+```
+
 ## testdata/dependency
 
 ```json

--- a/tests/snapshots/list__list_mutants_in_all_trees_as_json.snap
+++ b/tests/snapshots/list__list_mutants_in_all_trees_as_json.snap
@@ -728,11 +728,11 @@ expression: buf
       "span": {
         "end": {
           "column": 6,
-          "line": 10
+          "line": 14
         },
         "start": {
           "column": 5,
-          "line": 8
+          "line": 12
         }
       }
     },
@@ -742,11 +742,11 @@ expression: buf
     "span": {
       "end": {
         "column": 13,
-        "line": 9
+        "line": 13
       },
       "start": {
         "column": 9,
-        "line": 9
+        "line": 13
       }
     }
   }
@@ -3706,6 +3706,36 @@ expression: buf
   },
   {
     "file": "src/paths_in_lib/a_mod_file/inline/other.rs",
+    "function": {
+      "function_name": "always_true",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 3
+        },
+        "start": {
+          "column": 1,
+          "line": 1
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-nested-mod",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 9,
+        "line": 2
+      },
+      "start": {
+        "column": 5,
+        "line": 2
+      }
+    }
+  },
+  {
+    "file": "src/paths_in_lib/../upward_traversal_file_for_lib.rs",
     "function": {
       "function_name": "always_true",
       "return_type": "-> bool",

--- a/tests/snapshots/list__list_mutants_in_all_trees_as_text.snap
+++ b/tests/snapshots/list__list_mutants_in_all_trees_as_text.snap
@@ -222,8 +222,22 @@ src/lib.rs:2:5: replace returns_mut_ref -> &mut u32 with Box::leak(Box::new(1))
 ## testdata/nested_mod
 
 ```
+src/paths_in_lib/thread_files/tls.rs:2:5: replace always_true -> bool with false
+src/paths_in_lib/thread_files_inner_attr/tls.rs:2:5: replace always_true -> bool with false
+src/toplevel_file_in_lib.rs:2:5: replace always_true -> bool with false
+src/paths_in_main/thread_files/tls.rs:2:5: replace always_true -> bool with false
+src/paths_in_main/thread_files_inner_attr/tls.rs:2:5: replace always_true -> bool with false
+src/toplevel_file_in_main.rs:2:5: replace always_true -> bool with false
 src/block_in_lib/a/b/c_file/d/e/f_file.rs:2:5: replace always_true -> bool with false
+src/paths_in_lib/a/foo.rs:2:5: replace always_true -> bool with false
+src/paths_in_lib/a/b/inline/other.rs:2:5: replace always_true -> bool with false
+src/paths_in_lib/a_mod_file/foo.rs:2:5: replace always_true -> bool with false
+src/paths_in_lib/a_mod_file/inline/other.rs:2:5: replace always_true -> bool with false
 src/block_in_main/a/b/c_file/d/e/f_file.rs:2:5: replace always_true -> bool with false
+src/paths_in_main/a/foo.rs:2:5: replace always_true -> bool with false
+src/paths_in_main/a/b/inline/other.rs:2:5: replace always_true -> bool with false
+src/paths_in_main/a_mod_file/foo.rs:2:5: replace always_true -> bool with false
+src/paths_in_main/a_mod_file/inline/other.rs:2:5: replace always_true -> bool with false
 src/file_in_lib/a/b/c_file/d/e/f_file.rs:2:5: replace always_true -> bool with false
 src/file_in_main/a/b/c_file/d/e/f_file.rs:2:5: replace always_true -> bool with false
 ```

--- a/tests/snapshots/list__list_mutants_in_all_trees_as_text.snap
+++ b/tests/snapshots/list__list_mutants_in_all_trees_as_text.snap
@@ -67,7 +67,7 @@ src/custom_top.rs:2:7: replace % with + in is_even
 ## testdata/dangling_mod
 
 ```
-src/main.rs:9:9: replace verify_continue::always_true -> bool with false
+src/main.rs:13:9: replace verify_continue::always_true -> bool with false
 ```
 
 ## testdata/dependency
@@ -239,6 +239,7 @@ src/paths_in_lib/a/foo.rs:2:5: replace always_true -> bool with false
 src/paths_in_lib/a/b/inline/other.rs:2:5: replace always_true -> bool with false
 src/paths_in_lib/a_mod_file/foo.rs:2:5: replace always_true -> bool with false
 src/paths_in_lib/a_mod_file/inline/other.rs:2:5: replace always_true -> bool with false
+src/paths_in_lib/../upward_traversal_file_for_lib.rs:2:5: replace always_true -> bool with false
 src/block_in_main/a/b/c_file/d/e/f_file.rs:2:5: replace always_true -> bool with false
 src/paths_in_main/a/foo.rs:2:5: replace always_true -> bool with false
 src/paths_in_main/a/b/inline/other.rs:2:5: replace always_true -> bool with false

--- a/tests/snapshots/list__list_mutants_in_all_trees_as_text.snap
+++ b/tests/snapshots/list__list_mutants_in_all_trees_as_text.snap
@@ -64,6 +64,12 @@ src/custom_top.rs:2:7: replace % with / in is_even
 src/custom_top.rs:2:7: replace % with + in is_even
 ```
 
+## testdata/dangling_mod
+
+```
+src/main.rs:9:9: replace verify_continue::always_true -> bool with false
+```
+
 ## testdata/dependency
 
 ```


### PR DESCRIPTION
Following discussion in #335,

### Progress
- [x] Add tests based on [the reference](https://doc.rust-lang.org/reference/items/modules.html#the-path-attribute)
- [x] Add logic in `visit.rs` to follow path attributes `#[path="..."]` on modules
- [x] Verify paths do not contain `..` or **start with** `/`  (not a security boundary, but nice to have)
- [x] Report file/line/col of the `mod` statement on error

---
## Future tasks
This is a list of some enhancements that are not planned to be included in this PR:
- Add the command-line option to fail on "referent of mod not found".
    - I did verify tests pass with that `warn!` substituted with a `panic!`   (which means the `Ok(None)` return path may not be currently exercised by the test suite... it's fun thinking about how `cargo-mutants` can help improve its own test suite :slightly_smiling_face: )
- Address the TODO comment to refactor special handling of `mod.rs` to `SourceFile` itself (though the new tests should help with verifying that effort) https://github.com/sourcefrog/cargo-mutants/blob/961f1a3bc03e9d29e564f6c6b70f002c34e8437f/src/visit.rs#L469-L471
