### PR TITLE
Delete unary ops

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 - Document stability policy in the manual.
 
+- New: Generate mutations that delete the `!` and `-` unary operators.
+
 ## 24.3.0
 
 - Fixed: `cargo install cargo-mutants` without `--locked` was failing due to breaking API changes in some unstable dependencies.

--- a/book/src/mutants.md
+++ b/book/src/mutants.md
@@ -85,3 +85,9 @@ like `a == 0`.
 Equality operators are not currently replaced with comparisons like `<` or `<=`
 because they are
 too prone to generate false positives, for example when unsigned integers are compared to 0.
+
+## Unary operators
+
+Unary operators are deleted in expressions like `-a` and `!a`.
+They are not currently replaced with other unary operators because they are too prone to 
+generate unviable cases (e.g. `!1.0`, `-false`).

--- a/src/mutate.rs
+++ b/src/mutate.rs
@@ -120,8 +120,8 @@ impl Mutant {
             style(s.to_string())
         }
         let mut v: Vec<StyledObject<String>> = Vec::new();
-        v.push(s("replace "));
         if self.genre == Genre::FnValue {
+            v.push(s("replace "));
             let function = self
                 .function
                 .as_ref()
@@ -134,9 +134,16 @@ impl Mutant {
             v.push(s(" with "));
             v.push(s(self.replacement_text()).yellow());
         } else {
+            if self.replacement.is_empty() {
+                v.push(s("delete "));
+            } else {
+                v.push(s("replace "));
+            }
             v.push(s(self.original_text()).yellow());
-            v.push(s(" with "));
-            v.push(s(&self.replacement).bright().yellow());
+            if !self.replacement.is_empty() {
+                v.push(s(" with "));
+                v.push(s(&self.replacement).bright().yellow());
+            }
             if let Some(function) = &self.function {
                 v.push(s(" in "));
                 v.push(s(&function.function_name).bright().magenta());

--- a/src/mutate.rs
+++ b/src/mutate.rs
@@ -27,6 +27,7 @@ pub enum Genre {
     FnValue,
     /// Replace `==` with `!=` and so on.
     BinaryOperator,
+    UnaryOperator,
 }
 
 /// A mutation applied to source code.

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -16,7 +16,7 @@ use quote::{quote, ToTokens};
 use syn::ext::IdentExt;
 use syn::spanned::Spanned;
 use syn::visit::Visit;
-use syn::{Attribute, BinOp, Block, Expr, File, ItemFn, ReturnType, Signature};
+use syn::{Attribute, BinOp, Block, Expr, File, ItemFn, ReturnType, Signature, UnOp};
 use tracing::{debug, debug_span, trace, trace_span, warn};
 
 use crate::fnvalue::return_type_replacements;
@@ -434,6 +434,29 @@ impl<'ast> Visit<'ast> for DiscoveryVisitor<'_> {
             .into_iter()
             .for_each(|rep| self.collect_mutant(i.op.span().into(), rep, Genre::BinaryOperator));
         syn::visit::visit_expr_binary(self, i);
+    }
+
+    fn visit_expr_unary(&mut self, i: &'ast syn::ExprUnary) {
+        let _span = trace_span!("unary", line = i.op.span().start().line).entered();
+        trace!("visit unary operator");
+        if attrs_excluded(&i.attrs) {
+            return;
+        }
+        let replacements = match i.op {
+            UnOp::Not(_) => vec![quote! {}],
+            UnOp::Neg(_) => vec![quote! {}],
+            _ => {
+                trace!(
+                    op = i.op.to_pretty_string(),
+                    "No mutants generated for this unary operator"
+                );
+                Vec::new()
+            }
+        };
+        replacements
+            .into_iter()
+            .for_each(|rep| self.collect_mutant(i.op.span().into(), rep, Genre::UnaryOperator));
+        syn::visit::visit_expr_unary(self, i);
     }
 }
 

--- a/testdata/well_tested/src/booleans.rs
+++ b/testdata/well_tested/src/booleans.rs
@@ -1,0 +1,50 @@
+fn and(a: bool, b: bool) -> bool {
+    a && b
+}
+
+fn or(a: bool, b: bool) -> bool {
+    a || b
+}
+
+fn xor(a: bool, b: bool) -> bool {
+    a ^ b
+}
+
+fn not(a: bool) -> bool {
+    !a
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn all_and() {
+        assert_eq!(and(false, false), false);
+        assert_eq!(and(true, false), false);
+        assert_eq!(and(false, true), false);
+        assert_eq!(and(true, true), true);
+    }
+
+    #[test]
+    fn all_or() {
+        assert_eq!(or(false, false), false);
+        assert_eq!(or(true, false), true);
+        assert_eq!(or(false, true), true);
+        assert_eq!(or(true, true), true);
+    }
+
+    #[test]
+    fn all_xor() {
+        assert_eq!(xor(false, false), false);
+        assert_eq!(xor(true, false), true);
+        assert_eq!(xor(false, true), true);
+        assert_eq!(xor(true, true), false);
+    }
+
+    #[test]
+    fn all_not() {
+        assert_eq!(not(false), true);
+        assert_eq!(not(true), false);
+    }
+}

--- a/testdata/well_tested/src/lib.rs
+++ b/testdata/well_tested/src/lib.rs
@@ -9,6 +9,7 @@
 #![allow(unused, dead_code)]
 
 mod arc;
+mod booleans;
 mod empty_fns;
 mod inside_mod;
 mod item_mod;

--- a/testdata/well_tested/src/numbers.rs
+++ b/testdata/well_tested/src/numbers.rs
@@ -6,6 +6,22 @@ fn is_double(a: u32, b: u32) -> bool {
     a == 2 * b
 }
 
+fn negate_i32(a: i32) -> i32 {
+    -a
+}
+
+fn negate_f32(a: f32) -> f32 {
+    -a
+}
+
+fn bitwise_not_i32(a: i32) -> i32 {
+    !a
+}
+
+fn bitwise_not_u32(a: u32) -> u32 {
+    !a
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -30,5 +46,29 @@ mod test {
         assert!(is_double(2, 1));
         assert!(!is_double(1, 1));
         assert!(!is_double(5, 1));
+    }
+
+    #[test]
+    fn negate_one() {
+        assert_eq!(negate_i32(1), -1);
+        assert_eq!(negate_f32(1.0), -1.0);
+    }
+
+    #[test]
+    fn negate_two() {
+        assert_eq!(negate_i32(2), -2);
+        assert_eq!(negate_f32(2.0), -2.0);
+    }
+
+    #[test]
+    fn bitwise_not_one() {
+        assert_eq!(bitwise_not_i32(1), -2);
+        assert_eq!(bitwise_not_u32(1), u32::MAX - 1);
+    }
+
+    #[test]
+    fn bitwise_not_two() {
+        assert_eq!(bitwise_not_i32(2), -3);
+        assert_eq!(bitwise_not_u32(2), u32::MAX - 2);
     }
 }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -142,6 +142,7 @@ fn exclude_file_argument_overrides_config() {
         .args(["--exclude", "src/*_mod.rs"])
         .args(["--exclude", "src/s*.rs"])
         .args(["--exclude", "src/n*.rs"])
+        .args(["--exclude", "src/b*.rs"])
         .assert()
         .success()
         .stdout(predicates::str::diff(indoc! { "\

--- a/tests/snapshots/list__list_mutants_in_all_trees_as_json.snap
+++ b/tests/snapshots/list__list_mutants_in_all_trees_as_json.snap
@@ -5241,6 +5241,396 @@ expression: buf
     }
   },
   {
+    "file": "src/booleans.rs",
+    "function": {
+      "function_name": "and",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 3
+        },
+        "start": {
+          "column": 1,
+          "line": 1
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "true",
+    "span": {
+      "end": {
+        "column": 11,
+        "line": 2
+      },
+      "start": {
+        "column": 5,
+        "line": 2
+      }
+    }
+  },
+  {
+    "file": "src/booleans.rs",
+    "function": {
+      "function_name": "and",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 3
+        },
+        "start": {
+          "column": 1,
+          "line": 1
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 11,
+        "line": 2
+      },
+      "start": {
+        "column": 5,
+        "line": 2
+      }
+    }
+  },
+  {
+    "file": "src/booleans.rs",
+    "function": {
+      "function_name": "and",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 3
+        },
+        "start": {
+          "column": 1,
+          "line": 1
+        }
+      }
+    },
+    "genre": "BinaryOperator",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "||",
+    "span": {
+      "end": {
+        "column": 9,
+        "line": 2
+      },
+      "start": {
+        "column": 7,
+        "line": 2
+      }
+    }
+  },
+  {
+    "file": "src/booleans.rs",
+    "function": {
+      "function_name": "or",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 7
+        },
+        "start": {
+          "column": 1,
+          "line": 5
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "true",
+    "span": {
+      "end": {
+        "column": 11,
+        "line": 6
+      },
+      "start": {
+        "column": 5,
+        "line": 6
+      }
+    }
+  },
+  {
+    "file": "src/booleans.rs",
+    "function": {
+      "function_name": "or",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 7
+        },
+        "start": {
+          "column": 1,
+          "line": 5
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 11,
+        "line": 6
+      },
+      "start": {
+        "column": 5,
+        "line": 6
+      }
+    }
+  },
+  {
+    "file": "src/booleans.rs",
+    "function": {
+      "function_name": "or",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 7
+        },
+        "start": {
+          "column": 1,
+          "line": 5
+        }
+      }
+    },
+    "genre": "BinaryOperator",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "&&",
+    "span": {
+      "end": {
+        "column": 9,
+        "line": 6
+      },
+      "start": {
+        "column": 7,
+        "line": 6
+      }
+    }
+  },
+  {
+    "file": "src/booleans.rs",
+    "function": {
+      "function_name": "xor",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 11
+        },
+        "start": {
+          "column": 1,
+          "line": 9
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "true",
+    "span": {
+      "end": {
+        "column": 10,
+        "line": 10
+      },
+      "start": {
+        "column": 5,
+        "line": 10
+      }
+    }
+  },
+  {
+    "file": "src/booleans.rs",
+    "function": {
+      "function_name": "xor",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 11
+        },
+        "start": {
+          "column": 1,
+          "line": 9
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 10,
+        "line": 10
+      },
+      "start": {
+        "column": 5,
+        "line": 10
+      }
+    }
+  },
+  {
+    "file": "src/booleans.rs",
+    "function": {
+      "function_name": "xor",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 11
+        },
+        "start": {
+          "column": 1,
+          "line": 9
+        }
+      }
+    },
+    "genre": "BinaryOperator",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "|",
+    "span": {
+      "end": {
+        "column": 8,
+        "line": 10
+      },
+      "start": {
+        "column": 7,
+        "line": 10
+      }
+    }
+  },
+  {
+    "file": "src/booleans.rs",
+    "function": {
+      "function_name": "xor",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 11
+        },
+        "start": {
+          "column": 1,
+          "line": 9
+        }
+      }
+    },
+    "genre": "BinaryOperator",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "&",
+    "span": {
+      "end": {
+        "column": 8,
+        "line": 10
+      },
+      "start": {
+        "column": 7,
+        "line": 10
+      }
+    }
+  },
+  {
+    "file": "src/booleans.rs",
+    "function": {
+      "function_name": "not",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 15
+        },
+        "start": {
+          "column": 1,
+          "line": 13
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "true",
+    "span": {
+      "end": {
+        "column": 7,
+        "line": 14
+      },
+      "start": {
+        "column": 5,
+        "line": 14
+      }
+    }
+  },
+  {
+    "file": "src/booleans.rs",
+    "function": {
+      "function_name": "not",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 15
+        },
+        "start": {
+          "column": 1,
+          "line": 13
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 7,
+        "line": 14
+      },
+      "start": {
+        "column": 5,
+        "line": 14
+      }
+    }
+  },
+  {
+    "file": "src/booleans.rs",
+    "function": {
+      "function_name": "not",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 15
+        },
+        "start": {
+          "column": 1,
+          "line": 13
+        }
+      }
+    },
+    "genre": "UnaryOperator",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "",
+    "span": {
+      "end": {
+        "column": 6,
+        "line": 14
+      },
+      "start": {
+        "column": 5,
+        "line": 14
+      }
+    }
+  },
+  {
     "file": "src/inside_mod.rs",
     "function": {
       "function_name": "outer::inner::name",
@@ -5927,6 +6317,456 @@ expression: buf
       "start": {
         "column": 12,
         "line": 6
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "negate_i32",
+      "return_type": "-> i32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 11
+        },
+        "start": {
+          "column": 1,
+          "line": 9
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "0",
+    "span": {
+      "end": {
+        "column": 7,
+        "line": 10
+      },
+      "start": {
+        "column": 5,
+        "line": 10
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "negate_i32",
+      "return_type": "-> i32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 11
+        },
+        "start": {
+          "column": 1,
+          "line": 9
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "1",
+    "span": {
+      "end": {
+        "column": 7,
+        "line": 10
+      },
+      "start": {
+        "column": 5,
+        "line": 10
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "negate_i32",
+      "return_type": "-> i32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 11
+        },
+        "start": {
+          "column": 1,
+          "line": 9
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "-1",
+    "span": {
+      "end": {
+        "column": 7,
+        "line": 10
+      },
+      "start": {
+        "column": 5,
+        "line": 10
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "negate_i32",
+      "return_type": "-> i32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 11
+        },
+        "start": {
+          "column": 1,
+          "line": 9
+        }
+      }
+    },
+    "genre": "UnaryOperator",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "",
+    "span": {
+      "end": {
+        "column": 6,
+        "line": 10
+      },
+      "start": {
+        "column": 5,
+        "line": 10
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "negate_f32",
+      "return_type": "-> f32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 15
+        },
+        "start": {
+          "column": 1,
+          "line": 13
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "0.0",
+    "span": {
+      "end": {
+        "column": 7,
+        "line": 14
+      },
+      "start": {
+        "column": 5,
+        "line": 14
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "negate_f32",
+      "return_type": "-> f32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 15
+        },
+        "start": {
+          "column": 1,
+          "line": 13
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "1.0",
+    "span": {
+      "end": {
+        "column": 7,
+        "line": 14
+      },
+      "start": {
+        "column": 5,
+        "line": 14
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "negate_f32",
+      "return_type": "-> f32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 15
+        },
+        "start": {
+          "column": 1,
+          "line": 13
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "-1.0",
+    "span": {
+      "end": {
+        "column": 7,
+        "line": 14
+      },
+      "start": {
+        "column": 5,
+        "line": 14
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "negate_f32",
+      "return_type": "-> f32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 15
+        },
+        "start": {
+          "column": 1,
+          "line": 13
+        }
+      }
+    },
+    "genre": "UnaryOperator",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "",
+    "span": {
+      "end": {
+        "column": 6,
+        "line": 14
+      },
+      "start": {
+        "column": 5,
+        "line": 14
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "bitwise_not_i32",
+      "return_type": "-> i32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 19
+        },
+        "start": {
+          "column": 1,
+          "line": 17
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "0",
+    "span": {
+      "end": {
+        "column": 7,
+        "line": 18
+      },
+      "start": {
+        "column": 5,
+        "line": 18
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "bitwise_not_i32",
+      "return_type": "-> i32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 19
+        },
+        "start": {
+          "column": 1,
+          "line": 17
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "1",
+    "span": {
+      "end": {
+        "column": 7,
+        "line": 18
+      },
+      "start": {
+        "column": 5,
+        "line": 18
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "bitwise_not_i32",
+      "return_type": "-> i32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 19
+        },
+        "start": {
+          "column": 1,
+          "line": 17
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "-1",
+    "span": {
+      "end": {
+        "column": 7,
+        "line": 18
+      },
+      "start": {
+        "column": 5,
+        "line": 18
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "bitwise_not_i32",
+      "return_type": "-> i32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 19
+        },
+        "start": {
+          "column": 1,
+          "line": 17
+        }
+      }
+    },
+    "genre": "UnaryOperator",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "",
+    "span": {
+      "end": {
+        "column": 6,
+        "line": 18
+      },
+      "start": {
+        "column": 5,
+        "line": 18
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "bitwise_not_u32",
+      "return_type": "-> u32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 23
+        },
+        "start": {
+          "column": 1,
+          "line": 21
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "0",
+    "span": {
+      "end": {
+        "column": 7,
+        "line": 22
+      },
+      "start": {
+        "column": 5,
+        "line": 22
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "bitwise_not_u32",
+      "return_type": "-> u32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 23
+        },
+        "start": {
+          "column": 1,
+          "line": 21
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "1",
+    "span": {
+      "end": {
+        "column": 7,
+        "line": 22
+      },
+      "start": {
+        "column": 5,
+        "line": 22
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "bitwise_not_u32",
+      "return_type": "-> u32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 23
+        },
+        "start": {
+          "column": 1,
+          "line": 21
+        }
+      }
+    },
+    "genre": "UnaryOperator",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "",
+    "span": {
+      "end": {
+        "column": 6,
+        "line": 22
+      },
+      "start": {
+        "column": 5,
+        "line": 22
       }
     }
   },

--- a/tests/snapshots/list__list_mutants_in_all_trees_as_text.snap
+++ b/tests/snapshots/list__list_mutants_in_all_trees_as_text.snap
@@ -356,6 +356,19 @@ src/c.rs:2:5: replace one -> i32 with -1
 ```
 src/arc.rs:4:5: replace return_arc -> Arc<String> with Arc::new(String::new())
 src/arc.rs:4:5: replace return_arc -> Arc<String> with Arc::new("xyzzy".into())
+src/booleans.rs:2:5: replace and -> bool with true
+src/booleans.rs:2:5: replace and -> bool with false
+src/booleans.rs:2:7: replace && with || in and
+src/booleans.rs:6:5: replace or -> bool with true
+src/booleans.rs:6:5: replace or -> bool with false
+src/booleans.rs:6:7: replace || with && in or
+src/booleans.rs:10:5: replace xor -> bool with true
+src/booleans.rs:10:5: replace xor -> bool with false
+src/booleans.rs:10:7: replace ^ with | in xor
+src/booleans.rs:10:7: replace ^ with & in xor
+src/booleans.rs:14:5: replace not -> bool with true
+src/booleans.rs:14:5: replace not -> bool with false
+src/booleans.rs:14:5: delete ! in not
 src/inside_mod.rs:4:13: replace outer::inner::name -> &'static str with ""
 src/inside_mod.rs:4:13: replace outer::inner::name -> &'static str with "xyzzy"
 src/methods.rs:17:9: replace Foo::double with ()
@@ -379,6 +392,21 @@ src/numbers.rs:6:5: replace is_double -> bool with false
 src/numbers.rs:6:7: replace == with != in is_double
 src/numbers.rs:6:12: replace * with + in is_double
 src/numbers.rs:6:12: replace * with / in is_double
+src/numbers.rs:10:5: replace negate_i32 -> i32 with 0
+src/numbers.rs:10:5: replace negate_i32 -> i32 with 1
+src/numbers.rs:10:5: replace negate_i32 -> i32 with -1
+src/numbers.rs:10:5: delete - in negate_i32
+src/numbers.rs:14:5: replace negate_f32 -> f32 with 0.0
+src/numbers.rs:14:5: replace negate_f32 -> f32 with 1.0
+src/numbers.rs:14:5: replace negate_f32 -> f32 with -1.0
+src/numbers.rs:14:5: delete - in negate_f32
+src/numbers.rs:18:5: replace bitwise_not_i32 -> i32 with 0
+src/numbers.rs:18:5: replace bitwise_not_i32 -> i32 with 1
+src/numbers.rs:18:5: replace bitwise_not_i32 -> i32 with -1
+src/numbers.rs:18:5: delete ! in bitwise_not_i32
+src/numbers.rs:22:5: replace bitwise_not_u32 -> u32 with 0
+src/numbers.rs:22:5: replace bitwise_not_u32 -> u32 with 1
+src/numbers.rs:22:5: delete ! in bitwise_not_u32
 src/result.rs:6:5: replace simple_result -> Result<&'static str, ()> with Ok("")
 src/result.rs:6:5: replace simple_result -> Result<&'static str, ()> with Ok("xyzzy")
 src/result.rs:10:5: replace error_if_negative -> Result<(), ()> with Ok(())

--- a/tests/snapshots/main__well_tested_tree_check_only.snap
+++ b/tests/snapshots/main__well_tested_tree_check_only.snap
@@ -2,10 +2,23 @@
 source: tests/main.rs
 expression: stdout
 ---
-Found 66 mutants to test
+Found 94 mutants to test
 ok       Unmutated baseline
 ok       src/arc.rs:4:5: replace return_arc -> Arc<String> with Arc::new(String::new())
 ok       src/arc.rs:4:5: replace return_arc -> Arc<String> with Arc::new("xyzzy".into())
+ok       src/booleans.rs:2:5: replace and -> bool with true
+ok       src/booleans.rs:2:5: replace and -> bool with false
+ok       src/booleans.rs:2:7: replace && with || in and
+ok       src/booleans.rs:6:5: replace or -> bool with true
+ok       src/booleans.rs:6:5: replace or -> bool with false
+ok       src/booleans.rs:6:7: replace || with && in or
+ok       src/booleans.rs:10:5: replace xor -> bool with true
+ok       src/booleans.rs:10:5: replace xor -> bool with false
+ok       src/booleans.rs:10:7: replace ^ with | in xor
+ok       src/booleans.rs:10:7: replace ^ with & in xor
+ok       src/booleans.rs:14:5: replace not -> bool with true
+ok       src/booleans.rs:14:5: replace not -> bool with false
+ok       src/booleans.rs:14:5: delete ! in not
 ok       src/inside_mod.rs:4:13: replace outer::inner::name -> &'static str with ""
 ok       src/inside_mod.rs:4:13: replace outer::inner::name -> &'static str with "xyzzy"
 ok       src/methods.rs:17:9: replace Foo::double with ()
@@ -29,6 +42,21 @@ ok       src/numbers.rs:6:5: replace is_double -> bool with false
 ok       src/numbers.rs:6:7: replace == with != in is_double
 ok       src/numbers.rs:6:12: replace * with + in is_double
 ok       src/numbers.rs:6:12: replace * with / in is_double
+ok       src/numbers.rs:10:5: replace negate_i32 -> i32 with 0
+ok       src/numbers.rs:10:5: replace negate_i32 -> i32 with 1
+ok       src/numbers.rs:10:5: replace negate_i32 -> i32 with -1
+ok       src/numbers.rs:10:5: delete - in negate_i32
+ok       src/numbers.rs:14:5: replace negate_f32 -> f32 with 0.0
+ok       src/numbers.rs:14:5: replace negate_f32 -> f32 with 1.0
+ok       src/numbers.rs:14:5: replace negate_f32 -> f32 with -1.0
+ok       src/numbers.rs:14:5: delete - in negate_f32
+ok       src/numbers.rs:18:5: replace bitwise_not_i32 -> i32 with 0
+ok       src/numbers.rs:18:5: replace bitwise_not_i32 -> i32 with 1
+ok       src/numbers.rs:18:5: replace bitwise_not_i32 -> i32 with -1
+ok       src/numbers.rs:18:5: delete ! in bitwise_not_i32
+ok       src/numbers.rs:22:5: replace bitwise_not_u32 -> u32 with 0
+ok       src/numbers.rs:22:5: replace bitwise_not_u32 -> u32 with 1
+ok       src/numbers.rs:22:5: delete ! in bitwise_not_u32
 ok       src/result.rs:6:5: replace simple_result -> Result<&'static str, ()> with Ok("")
 ok       src/result.rs:6:5: replace simple_result -> Result<&'static str, ()> with Ok("xyzzy")
 ok       src/result.rs:10:5: replace error_if_negative -> Result<(), ()> with Ok(())
@@ -70,5 +98,4 @@ ok       src/struct_with_lifetime.rs:15:9: replace Lex<'buf>::buf_len -> usize w
 ok       src/traits.rs:5:9: replace Something::is_three -> bool with true
 ok       src/traits.rs:5:9: replace Something::is_three -> bool with false
 ok       src/traits.rs:5:11: replace == with != in Something::is_three
-66 mutants tested: 66 succeeded
-
+94 mutants tested: 94 succeeded

--- a/tests/snapshots/main__well_tested_tree_finds_no_problems.snap
+++ b/tests/snapshots/main__well_tested_tree_finds_no_problems.snap
@@ -2,10 +2,23 @@
 source: tests/main.rs
 expression: stdout
 ---
-Found 66 mutants to test
+Found 94 mutants to test
 ok       Unmutated baseline
 caught   src/arc.rs:4:5: replace return_arc -> Arc<String> with Arc::new(String::new())
 caught   src/arc.rs:4:5: replace return_arc -> Arc<String> with Arc::new("xyzzy".into())
+caught   src/booleans.rs:2:5: replace and -> bool with true
+caught   src/booleans.rs:2:5: replace and -> bool with false
+caught   src/booleans.rs:2:7: replace && with || in and
+caught   src/booleans.rs:6:5: replace or -> bool with true
+caught   src/booleans.rs:6:5: replace or -> bool with false
+caught   src/booleans.rs:6:7: replace || with && in or
+caught   src/booleans.rs:10:5: replace xor -> bool with true
+caught   src/booleans.rs:10:5: replace xor -> bool with false
+caught   src/booleans.rs:10:7: replace ^ with | in xor
+caught   src/booleans.rs:10:7: replace ^ with & in xor
+caught   src/booleans.rs:14:5: replace not -> bool with true
+caught   src/booleans.rs:14:5: replace not -> bool with false
+caught   src/booleans.rs:14:5: delete ! in not
 caught   src/inside_mod.rs:4:13: replace outer::inner::name -> &'static str with ""
 caught   src/inside_mod.rs:4:13: replace outer::inner::name -> &'static str with "xyzzy"
 caught   src/methods.rs:17:9: replace Foo::double with ()
@@ -29,6 +42,21 @@ caught   src/numbers.rs:6:5: replace is_double -> bool with false
 caught   src/numbers.rs:6:7: replace == with != in is_double
 caught   src/numbers.rs:6:12: replace * with + in is_double
 caught   src/numbers.rs:6:12: replace * with / in is_double
+caught   src/numbers.rs:10:5: replace negate_i32 -> i32 with 0
+caught   src/numbers.rs:10:5: replace negate_i32 -> i32 with 1
+caught   src/numbers.rs:10:5: replace negate_i32 -> i32 with -1
+caught   src/numbers.rs:10:5: delete - in negate_i32
+caught   src/numbers.rs:14:5: replace negate_f32 -> f32 with 0.0
+caught   src/numbers.rs:14:5: replace negate_f32 -> f32 with 1.0
+caught   src/numbers.rs:14:5: replace negate_f32 -> f32 with -1.0
+caught   src/numbers.rs:14:5: delete - in negate_f32
+caught   src/numbers.rs:18:5: replace bitwise_not_i32 -> i32 with 0
+caught   src/numbers.rs:18:5: replace bitwise_not_i32 -> i32 with 1
+caught   src/numbers.rs:18:5: replace bitwise_not_i32 -> i32 with -1
+caught   src/numbers.rs:18:5: delete ! in bitwise_not_i32
+caught   src/numbers.rs:22:5: replace bitwise_not_u32 -> u32 with 0
+caught   src/numbers.rs:22:5: replace bitwise_not_u32 -> u32 with 1
+caught   src/numbers.rs:22:5: delete ! in bitwise_not_u32
 caught   src/result.rs:6:5: replace simple_result -> Result<&'static str, ()> with Ok("")
 caught   src/result.rs:6:5: replace simple_result -> Result<&'static str, ()> with Ok("xyzzy")
 caught   src/result.rs:10:5: replace error_if_negative -> Result<(), ()> with Ok(())
@@ -70,5 +98,4 @@ caught   src/struct_with_lifetime.rs:15:9: replace Lex<'buf>::buf_len -> usize w
 caught   src/traits.rs:5:9: replace Something::is_three -> bool with true
 caught   src/traits.rs:5:9: replace Something::is_three -> bool with false
 caught   src/traits.rs:5:11: replace == with != in Something::is_three
-66 mutants tested: 66 caught
-
+94 mutants tested: 94 caught

--- a/tests/snapshots/main__well_tested_tree_finds_no_problems__caught.txt.snap
+++ b/tests/snapshots/main__well_tested_tree_finds_no_problems__caught.txt.snap
@@ -4,6 +4,19 @@ expression: content
 ---
 src/arc.rs:4:5: replace return_arc -> Arc<String> with Arc::new(String::new())
 src/arc.rs:4:5: replace return_arc -> Arc<String> with Arc::new("xyzzy".into())
+src/booleans.rs:2:5: replace and -> bool with true
+src/booleans.rs:2:5: replace and -> bool with false
+src/booleans.rs:2:7: replace && with || in and
+src/booleans.rs:6:5: replace or -> bool with true
+src/booleans.rs:6:5: replace or -> bool with false
+src/booleans.rs:6:7: replace || with && in or
+src/booleans.rs:10:5: replace xor -> bool with true
+src/booleans.rs:10:5: replace xor -> bool with false
+src/booleans.rs:10:7: replace ^ with | in xor
+src/booleans.rs:10:7: replace ^ with & in xor
+src/booleans.rs:14:5: replace not -> bool with true
+src/booleans.rs:14:5: replace not -> bool with false
+src/booleans.rs:14:5: delete ! in not
 src/inside_mod.rs:4:13: replace outer::inner::name -> &'static str with ""
 src/inside_mod.rs:4:13: replace outer::inner::name -> &'static str with "xyzzy"
 src/methods.rs:17:9: replace Foo::double with ()
@@ -27,6 +40,21 @@ src/numbers.rs:6:5: replace is_double -> bool with false
 src/numbers.rs:6:7: replace == with != in is_double
 src/numbers.rs:6:12: replace * with + in is_double
 src/numbers.rs:6:12: replace * with / in is_double
+src/numbers.rs:10:5: replace negate_i32 -> i32 with 0
+src/numbers.rs:10:5: replace negate_i32 -> i32 with 1
+src/numbers.rs:10:5: replace negate_i32 -> i32 with -1
+src/numbers.rs:10:5: delete - in negate_i32
+src/numbers.rs:14:5: replace negate_f32 -> f32 with 0.0
+src/numbers.rs:14:5: replace negate_f32 -> f32 with 1.0
+src/numbers.rs:14:5: replace negate_f32 -> f32 with -1.0
+src/numbers.rs:14:5: delete - in negate_f32
+src/numbers.rs:18:5: replace bitwise_not_i32 -> i32 with 0
+src/numbers.rs:18:5: replace bitwise_not_i32 -> i32 with 1
+src/numbers.rs:18:5: replace bitwise_not_i32 -> i32 with -1
+src/numbers.rs:18:5: delete ! in bitwise_not_i32
+src/numbers.rs:22:5: replace bitwise_not_u32 -> u32 with 0
+src/numbers.rs:22:5: replace bitwise_not_u32 -> u32 with 1
+src/numbers.rs:22:5: delete ! in bitwise_not_u32
 src/result.rs:6:5: replace simple_result -> Result<&'static str, ()> with Ok("")
 src/result.rs:6:5: replace simple_result -> Result<&'static str, ()> with Ok("xyzzy")
 src/result.rs:10:5: replace error_if_negative -> Result<(), ()> with Ok(())
@@ -68,4 +96,3 @@ src/struct_with_lifetime.rs:15:9: replace Lex<'buf>::buf_len -> usize with 1
 src/traits.rs:5:9: replace Something::is_three -> bool with true
 src/traits.rs:5:9: replace Something::is_three -> bool with false
 src/traits.rs:5:11: replace == with != in Something::is_three
-

--- a/tests/util/snapshots/list__util__list_files_json_well_tested.snap
+++ b/tests/util/snapshots/list__util__list_files_json_well_tested.snap
@@ -13,6 +13,10 @@ expression: "String::from_utf8_lossy(&output.stdout)"
   },
   {
     "package": "cargo-mutants-testdata-well-tested",
+    "path": "src/booleans.rs"
+  },
+  {
+    "package": "cargo-mutants-testdata-well-tested",
     "path": "src/empty_fns.rs"
   },
   {

--- a/tests/util/snapshots/list__util__list_files_text_well_tested.snap
+++ b/tests/util/snapshots/list__util__list_files_text_well_tested.snap
@@ -4,6 +4,7 @@ expression: "String::from_utf8_lossy(&output.stdout)"
 ---
 src/lib.rs
 src/arc.rs
+src/booleans.rs
 src/empty_fns.rs
 src/inside_mod.rs
 src/item_mod.rs

--- a/tests/util/snapshots/list__util__list_mutants_json_well_tested.snap
+++ b/tests/util/snapshots/list__util__list_mutants_json_well_tested.snap
@@ -64,6 +64,396 @@ expression: "String::from_utf8_lossy(&output.stdout)"
     }
   },
   {
+    "file": "src/booleans.rs",
+    "function": {
+      "function_name": "and",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 3
+        },
+        "start": {
+          "column": 1,
+          "line": 1
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "true",
+    "span": {
+      "end": {
+        "column": 11,
+        "line": 2
+      },
+      "start": {
+        "column": 5,
+        "line": 2
+      }
+    }
+  },
+  {
+    "file": "src/booleans.rs",
+    "function": {
+      "function_name": "and",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 3
+        },
+        "start": {
+          "column": 1,
+          "line": 1
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 11,
+        "line": 2
+      },
+      "start": {
+        "column": 5,
+        "line": 2
+      }
+    }
+  },
+  {
+    "file": "src/booleans.rs",
+    "function": {
+      "function_name": "and",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 3
+        },
+        "start": {
+          "column": 1,
+          "line": 1
+        }
+      }
+    },
+    "genre": "BinaryOperator",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "||",
+    "span": {
+      "end": {
+        "column": 9,
+        "line": 2
+      },
+      "start": {
+        "column": 7,
+        "line": 2
+      }
+    }
+  },
+  {
+    "file": "src/booleans.rs",
+    "function": {
+      "function_name": "or",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 7
+        },
+        "start": {
+          "column": 1,
+          "line": 5
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "true",
+    "span": {
+      "end": {
+        "column": 11,
+        "line": 6
+      },
+      "start": {
+        "column": 5,
+        "line": 6
+      }
+    }
+  },
+  {
+    "file": "src/booleans.rs",
+    "function": {
+      "function_name": "or",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 7
+        },
+        "start": {
+          "column": 1,
+          "line": 5
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 11,
+        "line": 6
+      },
+      "start": {
+        "column": 5,
+        "line": 6
+      }
+    }
+  },
+  {
+    "file": "src/booleans.rs",
+    "function": {
+      "function_name": "or",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 7
+        },
+        "start": {
+          "column": 1,
+          "line": 5
+        }
+      }
+    },
+    "genre": "BinaryOperator",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "&&",
+    "span": {
+      "end": {
+        "column": 9,
+        "line": 6
+      },
+      "start": {
+        "column": 7,
+        "line": 6
+      }
+    }
+  },
+  {
+    "file": "src/booleans.rs",
+    "function": {
+      "function_name": "xor",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 11
+        },
+        "start": {
+          "column": 1,
+          "line": 9
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "true",
+    "span": {
+      "end": {
+        "column": 10,
+        "line": 10
+      },
+      "start": {
+        "column": 5,
+        "line": 10
+      }
+    }
+  },
+  {
+    "file": "src/booleans.rs",
+    "function": {
+      "function_name": "xor",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 11
+        },
+        "start": {
+          "column": 1,
+          "line": 9
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 10,
+        "line": 10
+      },
+      "start": {
+        "column": 5,
+        "line": 10
+      }
+    }
+  },
+  {
+    "file": "src/booleans.rs",
+    "function": {
+      "function_name": "xor",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 11
+        },
+        "start": {
+          "column": 1,
+          "line": 9
+        }
+      }
+    },
+    "genre": "BinaryOperator",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "|",
+    "span": {
+      "end": {
+        "column": 8,
+        "line": 10
+      },
+      "start": {
+        "column": 7,
+        "line": 10
+      }
+    }
+  },
+  {
+    "file": "src/booleans.rs",
+    "function": {
+      "function_name": "xor",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 11
+        },
+        "start": {
+          "column": 1,
+          "line": 9
+        }
+      }
+    },
+    "genre": "BinaryOperator",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "&",
+    "span": {
+      "end": {
+        "column": 8,
+        "line": 10
+      },
+      "start": {
+        "column": 7,
+        "line": 10
+      }
+    }
+  },
+  {
+    "file": "src/booleans.rs",
+    "function": {
+      "function_name": "not",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 15
+        },
+        "start": {
+          "column": 1,
+          "line": 13
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "true",
+    "span": {
+      "end": {
+        "column": 7,
+        "line": 14
+      },
+      "start": {
+        "column": 5,
+        "line": 14
+      }
+    }
+  },
+  {
+    "file": "src/booleans.rs",
+    "function": {
+      "function_name": "not",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 15
+        },
+        "start": {
+          "column": 1,
+          "line": 13
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 7,
+        "line": 14
+      },
+      "start": {
+        "column": 5,
+        "line": 14
+      }
+    }
+  },
+  {
+    "file": "src/booleans.rs",
+    "function": {
+      "function_name": "not",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 15
+        },
+        "start": {
+          "column": 1,
+          "line": 13
+        }
+      }
+    },
+    "genre": "UnaryOperator",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "",
+    "span": {
+      "end": {
+        "column": 6,
+        "line": 14
+      },
+      "start": {
+        "column": 5,
+        "line": 14
+      }
+    }
+  },
+  {
     "file": "src/inside_mod.rs",
     "function": {
       "function_name": "outer::inner::name",
@@ -750,6 +1140,456 @@ expression: "String::from_utf8_lossy(&output.stdout)"
       "start": {
         "column": 12,
         "line": 6
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "negate_i32",
+      "return_type": "-> i32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 11
+        },
+        "start": {
+          "column": 1,
+          "line": 9
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "0",
+    "span": {
+      "end": {
+        "column": 7,
+        "line": 10
+      },
+      "start": {
+        "column": 5,
+        "line": 10
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "negate_i32",
+      "return_type": "-> i32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 11
+        },
+        "start": {
+          "column": 1,
+          "line": 9
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "1",
+    "span": {
+      "end": {
+        "column": 7,
+        "line": 10
+      },
+      "start": {
+        "column": 5,
+        "line": 10
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "negate_i32",
+      "return_type": "-> i32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 11
+        },
+        "start": {
+          "column": 1,
+          "line": 9
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "-1",
+    "span": {
+      "end": {
+        "column": 7,
+        "line": 10
+      },
+      "start": {
+        "column": 5,
+        "line": 10
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "negate_i32",
+      "return_type": "-> i32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 11
+        },
+        "start": {
+          "column": 1,
+          "line": 9
+        }
+      }
+    },
+    "genre": "UnaryOperator",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "",
+    "span": {
+      "end": {
+        "column": 6,
+        "line": 10
+      },
+      "start": {
+        "column": 5,
+        "line": 10
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "negate_f32",
+      "return_type": "-> f32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 15
+        },
+        "start": {
+          "column": 1,
+          "line": 13
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "0.0",
+    "span": {
+      "end": {
+        "column": 7,
+        "line": 14
+      },
+      "start": {
+        "column": 5,
+        "line": 14
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "negate_f32",
+      "return_type": "-> f32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 15
+        },
+        "start": {
+          "column": 1,
+          "line": 13
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "1.0",
+    "span": {
+      "end": {
+        "column": 7,
+        "line": 14
+      },
+      "start": {
+        "column": 5,
+        "line": 14
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "negate_f32",
+      "return_type": "-> f32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 15
+        },
+        "start": {
+          "column": 1,
+          "line": 13
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "-1.0",
+    "span": {
+      "end": {
+        "column": 7,
+        "line": 14
+      },
+      "start": {
+        "column": 5,
+        "line": 14
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "negate_f32",
+      "return_type": "-> f32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 15
+        },
+        "start": {
+          "column": 1,
+          "line": 13
+        }
+      }
+    },
+    "genre": "UnaryOperator",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "",
+    "span": {
+      "end": {
+        "column": 6,
+        "line": 14
+      },
+      "start": {
+        "column": 5,
+        "line": 14
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "bitwise_not_i32",
+      "return_type": "-> i32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 19
+        },
+        "start": {
+          "column": 1,
+          "line": 17
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "0",
+    "span": {
+      "end": {
+        "column": 7,
+        "line": 18
+      },
+      "start": {
+        "column": 5,
+        "line": 18
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "bitwise_not_i32",
+      "return_type": "-> i32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 19
+        },
+        "start": {
+          "column": 1,
+          "line": 17
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "1",
+    "span": {
+      "end": {
+        "column": 7,
+        "line": 18
+      },
+      "start": {
+        "column": 5,
+        "line": 18
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "bitwise_not_i32",
+      "return_type": "-> i32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 19
+        },
+        "start": {
+          "column": 1,
+          "line": 17
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "-1",
+    "span": {
+      "end": {
+        "column": 7,
+        "line": 18
+      },
+      "start": {
+        "column": 5,
+        "line": 18
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "bitwise_not_i32",
+      "return_type": "-> i32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 19
+        },
+        "start": {
+          "column": 1,
+          "line": 17
+        }
+      }
+    },
+    "genre": "UnaryOperator",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "",
+    "span": {
+      "end": {
+        "column": 6,
+        "line": 18
+      },
+      "start": {
+        "column": 5,
+        "line": 18
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "bitwise_not_u32",
+      "return_type": "-> u32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 23
+        },
+        "start": {
+          "column": 1,
+          "line": 21
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "0",
+    "span": {
+      "end": {
+        "column": 7,
+        "line": 22
+      },
+      "start": {
+        "column": 5,
+        "line": 22
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "bitwise_not_u32",
+      "return_type": "-> u32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 23
+        },
+        "start": {
+          "column": 1,
+          "line": 21
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "1",
+    "span": {
+      "end": {
+        "column": 7,
+        "line": 22
+      },
+      "start": {
+        "column": 5,
+        "line": 22
+      }
+    }
+  },
+  {
+    "file": "src/numbers.rs",
+    "function": {
+      "function_name": "bitwise_not_u32",
+      "return_type": "-> u32",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 23
+        },
+        "start": {
+          "column": 1,
+          "line": 21
+        }
+      }
+    },
+    "genre": "UnaryOperator",
+    "package": "cargo-mutants-testdata-well-tested",
+    "replacement": "",
+    "span": {
+      "end": {
+        "column": 6,
+        "line": 22
+      },
+      "start": {
+        "column": 5,
+        "line": 22
       }
     }
   },

--- a/tests/util/snapshots/list__util__list_mutants_well_tested.snap
+++ b/tests/util/snapshots/list__util__list_mutants_well_tested.snap
@@ -4,6 +4,19 @@ expression: "String::from_utf8_lossy(&output.stdout)"
 ---
 src/arc.rs:4:5: replace return_arc -> Arc<String> with Arc::new(String::new())
 src/arc.rs:4:5: replace return_arc -> Arc<String> with Arc::new("xyzzy".into())
+src/booleans.rs:2:5: replace and -> bool with true
+src/booleans.rs:2:5: replace and -> bool with false
+src/booleans.rs:2:7: replace && with || in and
+src/booleans.rs:6:5: replace or -> bool with true
+src/booleans.rs:6:5: replace or -> bool with false
+src/booleans.rs:6:7: replace || with && in or
+src/booleans.rs:10:5: replace xor -> bool with true
+src/booleans.rs:10:5: replace xor -> bool with false
+src/booleans.rs:10:7: replace ^ with | in xor
+src/booleans.rs:10:7: replace ^ with & in xor
+src/booleans.rs:14:5: replace not -> bool with true
+src/booleans.rs:14:5: replace not -> bool with false
+src/booleans.rs:14:5: delete ! in not
 src/inside_mod.rs:4:13: replace outer::inner::name -> &'static str with ""
 src/inside_mod.rs:4:13: replace outer::inner::name -> &'static str with "xyzzy"
 src/methods.rs:17:9: replace Foo::double with ()
@@ -27,6 +40,21 @@ src/numbers.rs:6:5: replace is_double -> bool with false
 src/numbers.rs:6:7: replace == with != in is_double
 src/numbers.rs:6:12: replace * with + in is_double
 src/numbers.rs:6:12: replace * with / in is_double
+src/numbers.rs:10:5: replace negate_i32 -> i32 with 0
+src/numbers.rs:10:5: replace negate_i32 -> i32 with 1
+src/numbers.rs:10:5: replace negate_i32 -> i32 with -1
+src/numbers.rs:10:5: delete - in negate_i32
+src/numbers.rs:14:5: replace negate_f32 -> f32 with 0.0
+src/numbers.rs:14:5: replace negate_f32 -> f32 with 1.0
+src/numbers.rs:14:5: replace negate_f32 -> f32 with -1.0
+src/numbers.rs:14:5: delete - in negate_f32
+src/numbers.rs:18:5: replace bitwise_not_i32 -> i32 with 0
+src/numbers.rs:18:5: replace bitwise_not_i32 -> i32 with 1
+src/numbers.rs:18:5: replace bitwise_not_i32 -> i32 with -1
+src/numbers.rs:18:5: delete ! in bitwise_not_i32
+src/numbers.rs:22:5: replace bitwise_not_u32 -> u32 with 0
+src/numbers.rs:22:5: replace bitwise_not_u32 -> u32 with 1
+src/numbers.rs:22:5: delete ! in bitwise_not_u32
 src/result.rs:6:5: replace simple_result -> Result<&'static str, ()> with Ok("")
 src/result.rs:6:5: replace simple_result -> Result<&'static str, ()> with Ok("xyzzy")
 src/result.rs:10:5: replace error_if_negative -> Result<(), ()> with Ok(())

--- a/tests/util/snapshots/list__util__list_mutants_well_tested_exclude_name_filter.snap
+++ b/tests/util/snapshots/list__util__list_mutants_well_tested_exclude_name_filter.snap
@@ -4,6 +4,19 @@ expression: "String::from_utf8_lossy(&output.stdout)"
 ---
 src/arc.rs:4:5: replace return_arc -> Arc<String> with Arc::new(String::new())
 src/arc.rs:4:5: replace return_arc -> Arc<String> with Arc::new("xyzzy".into())
+src/booleans.rs:2:5: replace and -> bool with true
+src/booleans.rs:2:5: replace and -> bool with false
+src/booleans.rs:2:7: replace && with || in and
+src/booleans.rs:6:5: replace or -> bool with true
+src/booleans.rs:6:5: replace or -> bool with false
+src/booleans.rs:6:7: replace || with && in or
+src/booleans.rs:10:5: replace xor -> bool with true
+src/booleans.rs:10:5: replace xor -> bool with false
+src/booleans.rs:10:7: replace ^ with | in xor
+src/booleans.rs:10:7: replace ^ with & in xor
+src/booleans.rs:14:5: replace not -> bool with true
+src/booleans.rs:14:5: replace not -> bool with false
+src/booleans.rs:14:5: delete ! in not
 src/inside_mod.rs:4:13: replace outer::inner::name -> &'static str with ""
 src/inside_mod.rs:4:13: replace outer::inner::name -> &'static str with "xyzzy"
 src/methods.rs:17:9: replace Foo::double with ()
@@ -27,6 +40,21 @@ src/numbers.rs:6:5: replace is_double -> bool with false
 src/numbers.rs:6:7: replace == with != in is_double
 src/numbers.rs:6:12: replace * with + in is_double
 src/numbers.rs:6:12: replace * with / in is_double
+src/numbers.rs:10:5: replace negate_i32 -> i32 with 0
+src/numbers.rs:10:5: replace negate_i32 -> i32 with 1
+src/numbers.rs:10:5: replace negate_i32 -> i32 with -1
+src/numbers.rs:10:5: delete - in negate_i32
+src/numbers.rs:14:5: replace negate_f32 -> f32 with 0.0
+src/numbers.rs:14:5: replace negate_f32 -> f32 with 1.0
+src/numbers.rs:14:5: replace negate_f32 -> f32 with -1.0
+src/numbers.rs:14:5: delete - in negate_f32
+src/numbers.rs:18:5: replace bitwise_not_i32 -> i32 with 0
+src/numbers.rs:18:5: replace bitwise_not_i32 -> i32 with 1
+src/numbers.rs:18:5: replace bitwise_not_i32 -> i32 with -1
+src/numbers.rs:18:5: delete ! in bitwise_not_i32
+src/numbers.rs:22:5: replace bitwise_not_u32 -> u32 with 0
+src/numbers.rs:22:5: replace bitwise_not_u32 -> u32 with 1
+src/numbers.rs:22:5: delete ! in bitwise_not_u32
 src/result.rs:6:5: replace simple_result -> Result<&'static str, ()> with Ok("")
 src/result.rs:6:5: replace simple_result -> Result<&'static str, ()> with Ok("xyzzy")
 src/result.rs:10:5: replace error_if_negative -> Result<(), ()> with Ok(())


### PR DESCRIPTION
Fixes #201

I added some test cases in the `well_tested` test crate, but I feel like I should add some test cases for a few unviable mutations (e.g. `!1.0`, `let x: u32 = -1`). I wasn't sure where exactly I should put these, hence the draft PR.

The only existing place I saw asserting unviable cases were for `struct_with_no_default`. Should I create a new crate under `testdata/` for unviable unary operators?