### PR TITLE
Update GitHub actions in basic CI example

### DIFF
--- a/examples/workflows/basic.yml
+++ b/examples/workflows/basic.yml
@@ -27,7 +27,7 @@ jobs:
   cargo-mutants:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/examples/workflows/basic.yml
+++ b/examples/workflows/basic.yml
@@ -28,9 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
       - uses: taiki-e/install-action@v2
         with:
           tool: cargo-mutants


### PR DESCRIPTION
This updates the `checkout` action version to the latest (v4), since v2 produces warnings about deprecated Node.js version.

Also, the use of [`actions-rs/toolchain`](https://github.com/actions-rs/toolchain) is removed as the action is no longer maintained. AFAICT, `rustup` is available in GitHub runners, but I am not sure if an extra step like `rustup update stable && rustup default stable` is necessary in the worklow? Please let me know if it should be added.