### PR TITLE
Use `cargo test --no-run` rather than `cargo build`

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -178,6 +178,10 @@ Various output files, including the text output from all the cargo commands are
 written into `mutants.out` within the directory specified by `--output`, or by
 default the source directory.
 
+## Cargo quirks
+
+To build the tests, we actually run `cargo test --no-test` (or similarly for Nextest) so that the build uses the same profile as the tests. This is because the tests are built with the `test` profile, which can have different settings from the `dev` profile.
+
 ## Handling strict lints
 
 Some trees are configured so that any unused variable is an error. This is a reasonable choice to keep the tree very clean in CI, but if unhandled it would be a problem for cargo mutants. Many mutants -- in fact at the time of writing all generated mutants -- ignore function parameters and return a static value. Rejecting them due to the lint failure is a missed opportunity to consider a similar but more subtle potential bug.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,13 +2,15 @@
 
 ## Unreleased
 
+- Changes: Baselines and mutants are now built with `cargo test --no-run` rather than `cargo build --tests` as previously. This avoids wasted build effort if the `dev` and `test` Cargo profiles are not the same, and may better distinguish build failures from test failures. With `--test-tool=nextest`, the corresponding `cargo nextest run --no-run` is used.
+
 - Fixed: `.ignore` files can no longer affect source tree copying, so test files listed in a `.ignore` (e.g. `*.snap` for Insta snapshots) are now correctly copied into temporary build directories.
 
 - Fixed: Don't visit files marked with `#![cfg(test)]` (or other inner attributes that generally cause code to be skipped.)
 
 - Fixed: Paths to module files nested within `mod` blocks are now correctly resolved.
 
-- Document stability policy in the manual.
+- Added: Document stability policy in the manual.
 
 ## 24.3.0
 

--- a/book/src/cargo-args.md
+++ b/book/src/cargo-args.md
@@ -1,6 +1,6 @@
 # Passing options to Cargo
 
-cargo-mutants runs `cargo build` and `cargo test` (or, with `--check`, it runs
+cargo-mutants runs `cargo test` to build and run tests. (With `--check`, it runs
 `cargo check`.) Additional options can be passed in three different ways: to all
 `cargo` commands; to `cargo test` only; and to the test binaries run by `cargo
 test`.
@@ -9,7 +9,7 @@ There is not yet a way to pass options only to `cargo build` but not to `cargo t
 
 ## Feature flags
 
-The `--features`, `--all-features`, and `--no-default-features` flags can be given to cargo-mutants and they will be passed down to `cargo build` and `cargo test`.
+The `--features`, `--all-features`, and `--no-default-features` flags can be given to cargo-mutants and they will be passed down to cargo invocations.
 
 For example, this can be useful if you have tests that are only enabled with a feature flag:
 

--- a/book/src/getting-started.md
+++ b/book/src/getting-started.md
@@ -6,13 +6,13 @@ functions that may be inadequately tested.
 ## Prerequisites
 
 For cargo-mutants to give useful results, your tree must already
-
-1. Be built with `cargo build`, and
-2. Have reliable non-flaky tests that run under either `cargo test` or `cargo nextest`.
+have reliable non-flaky tests that run under either `cargo test` or `cargo nextest`.
 
 If the tests are flaky, meaning that they can pass or fail depending on factors other than the source tree, then the cargo-mutants results will be meaningless.
 
 Cross-compilation is not currently supported, so the tree must be buildable for the host platform.
+
+Build tools other than Cargo are not supported today, but could in principle be added.
 
 ## Example
 

--- a/book/src/how-it-works.md
+++ b/book/src/how-it-works.md
@@ -26,7 +26,7 @@ The basic approach is:
 
 - For each mutation:
   - Apply the mutation to the scratch tree by patching the affected file.
-  - Run `cargo build`: if this fails, the mutant is unviable, and that's ok.
+  - Run `cargo test --no-run`: if this fails, the mutant is unviable, and that's ok.
   - Run `cargo test` in the tree, saving output to a log file.
   - If the the tests fail, that's good: the mutation was somehow
     caught.

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -406,7 +406,7 @@ fn small_well_tested_mutants_with_cargo_arg_release() {
     println!("{}", baseline_log_path.display());
     let log_content = fs::read_to_string(baseline_log_path).unwrap();
     println!("{log_content}");
-    regex::Regex::new(r"cargo.* build --tests --manifest-path .* --release")
+    regex::Regex::new(r"cargo.* test --no-run --manifest-path .* --release")
         .unwrap()
         .captures(&log_content)
         .unwrap();
@@ -570,7 +570,7 @@ fn source_tree_typecheck_fails() {
                 .name("The problem source line"),
         )
         .stdout(contains("*** baseline"))
-        .stdout(contains("build --tests")) // Caught at the check phase
+        .stdout(contains("test --no-run"))
         .stdout(contains("lib.rs:6"))
         .stdout(contains("*** result: "))
         .stderr(contains(

--- a/tests/workspace.rs
+++ b/tests/workspace.rs
@@ -132,7 +132,7 @@ fn workspace_tree_is_well_tested() {
         assert_eq!(baseline_phases[0]["process_status"], "Success");
         assert_eq!(
             baseline_phases[0]["argv"].as_array().unwrap().iter().map(|v| v.as_str().unwrap()).skip(1).collect_vec().join(" "),
-            "build --tests --package cargo_mutants_testdata_workspace_utils --package main --package main2"
+            "test --no-run --package cargo_mutants_testdata_workspace_utils --package main --package main2"
         );
         assert_eq!(baseline_phases[1]["process_status"], "Success");
         assert_eq!(
@@ -159,7 +159,7 @@ fn workspace_tree_is_well_tested() {
         assert_eq!(mutant_phases[0]["process_status"], "Success");
         assert_eq!(
             mutant_phases[0]["argv"].as_array().unwrap()[1..=3],
-            ["build", "--tests", "--manifest-path"]
+            ["test", "--no-run", "--manifest-path"]
         );
         assert_eq!(mutant_phases[1]["process_status"], json!({"Failure": 101}));
         assert_eq!(
@@ -176,7 +176,7 @@ fn workspace_tree_is_well_tested() {
         assert_eq!(baseline_phases[0]["process_status"], "Success");
         assert_eq!(
             baseline_phases[0]["argv"].as_array().unwrap()[1..].iter().map(|v| v.as_str().unwrap()).join(" "),
-            "build --tests --package cargo_mutants_testdata_workspace_utils --package main --package main2",
+            "test --no-run --package cargo_mutants_testdata_workspace_utils --package main --package main2",
         );
         assert_eq!(baseline_phases[1]["process_status"], "Success");
         assert_eq!(


### PR DESCRIPTION
Similarly for Nextest.

This should avoid rebuilds if the dev and test profiles are different, and maybe better expresses the intention of "get everything ready to test without actually running the tests."

Fixes #237