### PR TITLE
Add timeouts for builds

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - New: `--build-timeout` and `--build-timeout-multiplier` options for setting timeouts for the `build` and `check` cargo phases.
 
+- Changed: `--timeout-multiplier` now overrides `timeout_multiplier` from `.cargo/mutants.toml`.
+
 ## 24.4.0
 
 - Changes: Baselines and mutants are now built with `cargo test --no-run` rather than `cargo build --tests` as previously. This avoids wasted build effort if the `dev` and `test` Cargo profiles are not the same, and may better distinguish build failures from test failures. With `--test-tool=nextest`, the corresponding `cargo nextest run --no-run` is used.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- New: `--build-timeout` and `--build-timeout-multiplier` options for setting timeouts for the `build` and `check` cargo phases.
+
 ## 24.4.0
 
 - Changes: Baselines and mutants are now built with `cargo test --no-run` rather than `cargo build --tests` as previously. This avoids wasted build effort if the `dev` and `test` Cargo profiles are not the same, and may better distinguish build failures from test failures. With `--test-tool=nextest`, the corresponding `cargo nextest run --no-run` is used.

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 - Changed: `--timeout-multiplier` now overrides `timeout_multiplier` from `.cargo/mutants.toml`.
 
+- Changed: `--timeout` and `--timeout-multiplier` are now conflicting options.
+
 ## 24.4.0
 
 - Changes: Baselines and mutants are now built with `cargo test --no-run` rather than `cargo build --tests` as previously. This avoids wasted build effort if the `dev` and `test` Cargo profiles are not the same, and may better distinguish build failures from test failures. With `--test-tool=nextest`, the corresponding `cargo nextest run --no-run` is used.

--- a/book/src/timeouts.md
+++ b/book/src/timeouts.md
@@ -16,21 +16,35 @@ file](filter_mutants.md).
 
 ## Timeouts
 
-To avoid hangs, cargo-mutants will kill the test suite after a timeout and
+To avoid hangs, cargo-mutants will kill the build or test after a timeout and
 continue to the next mutant.
 
-By default, the timeout is set automatically. cargo-mutants measures the time to
-run the test suite in the unmodified tree, and then sets a timeout for mutated
-tests at 5x the time to run tests with no mutations, and a minimum of 20
-seconds.
+By default, the timeouts are set automatically, relative to the times taken to
+build and test the unmodified tree (baseline).
 
-The minimum of 20 seconds can be overridden by the
-`CARGO_MUTANTS_MINIMUM_TEST_TIMEOUT` environment variable, measured in seconds.
+The default timeouts are:
+- `cargo build`/`cargo check`: 2 times the baseline build time
+- `cargo test`: 5 times baseline test time (with a minimum of 20 seconds)
 
-You can also set an explicit timeout with the `--timeout` option, also measured
-in seconds. If this option is specified then the timeout is also applied to the
-unmutated tests.
+The minimum of 20 seconds for the test timeout can be overridden by the
+`--minimum-test-timeout` option or the `CARGO_MUTANTS_MINIMUM_TEST_TIMEOUT` 
+environment variable, measured in seconds.
 
-You can set a timeout multiplier that is relative to the duration of the unmutated tests with `--timeout-multiplier` or setting `timeout_multiplier` in `.cargo/mutants.toml` (`timeout-multiplier = 1.5`). This option is only applied if the baseline is not skipped and no `--timeout` option is specified, otherwise it is ignored.
+You can set explicit timeouts with the `--build-timeout`, and `--timeout`
+options, also measured in seconds. If these options are specified then they 
+are applied to the baseline build and test as well.
 
-The timeout does not apply to `cargo check` or `cargo build`, only `cargo test`.
+You can set timeout multipliers that are relative to the duration of the
+baseline build or test with `--build-timeout-multiplier` and
+`--timeout-multiplier`, respectively.  Additionally, these can be configured
+with `build_timeout_multiplier` and `timeout_multiplier` in
+`.cargo/mutants.toml` (e.g. `timeout-multiplier = 1.5`).  These options are only
+applied if the baseline is not skipped and no corresponding
+`--build-timeout`/`--timeout` option is specified, otherwise they are ignored.
+
+## Exceptions
+
+The multiplier timeout options cannot be used when the baseline is skipped
+(`--baseline=skip`), or when the build is in-place (`--in-place`). If no 
+explicit timeouts is provided in these cases, then a default of 300 seconds
+will be used.

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,8 @@ pub struct Config {
     pub test_tool: Option<TestTool>,
     /// Timeout multiplier, relative to the baseline 'cargo test'.
     pub timeout_multiplier: Option<f64>,
+    /// Build timeout multiplier, relative to the baseline 'cargo build'.
+    pub build_timeout_multiplier: Option<f64>,
 }
 
 impl Config {

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -65,7 +65,10 @@ pub fn test_mutants(
                 &output_mutex,
                 &Scenario::Baseline,
                 &all_packages,
-                options.test_timeout.unwrap_or(Duration::MAX),
+                Timeouts {
+                    test: options.test_timeout.unwrap_or(Duration::MAX),
+                    build: options.build_timeout.unwrap_or(Duration::MAX),
+                },
                 &options,
                 console,
             )?;
@@ -86,12 +89,17 @@ pub fn test_mutants(
         BaselineStrategy::Skip => None,
     };
     let mut build_dirs = vec![build_dir];
-    let baseline_test_duration = baseline_outcome
-        .as_ref()
-        .and_then(|so| so.phase_result(Phase::Test))
-        .map(|pr| pr.duration);
 
-    let test_timeout = test_timeout(baseline_test_duration, &options);
+    let baseline_duration_by_phase = |phase| {
+        baseline_outcome
+            .as_ref()
+            .and_then(|so| so.phase_result(phase))
+            .map(|pr| pr.duration)
+    };
+    let timeouts = Timeouts {
+        build: build_timeout(baseline_duration_by_phase(Phase::Build), &options),
+        test: test_timeout(baseline_duration_by_phase(Phase::Test), &options),
+    };
 
     let jobs = max(1, min(options.jobs.unwrap_or(1), mutants.len()));
     for i in 1..jobs {
@@ -134,7 +142,7 @@ pub fn test_mutants(
                                 &output_mutex,
                                 &Scenario::Mutant(mutant),
                                 &[&package],
-                                test_timeout,
+                                timeouts,
                                 &options,
                                 console,
                             )?;
@@ -190,31 +198,76 @@ pub fn test_mutants(
     Ok(lab_outcome)
 }
 
-fn test_timeout(baseline_test_duration: Option<Duration>, options: &Options) -> Duration {
-    if let Some(timeout) = options.test_timeout {
-        timeout
-    } else if options.check_only {
-        Duration::ZERO
-    } else if let Some(baseline_test_duration) = baseline_test_duration {
-        let timeout = max(
-            options.minimum_test_timeout,
-            Duration::from_secs(
-                (baseline_test_duration.as_secs_f64()
-                    * options.test_timeout_multiplier.unwrap_or(5.0))
-                .round() as u64,
-            ),
-        );
-        if options.show_times {
-            info!(
-                "Auto-set test timeout to {}",
-                humantime::format_duration(timeout)
-            );
-        }
-        timeout
-    } else {
-        warn!("An explicit timeout is recommended when using --baseline=skip; using 300 seconds by default");
-        Duration::from_secs(300)
+#[derive(Copy, Clone)]
+struct Timeouts {
+    build: Duration,
+    test: Duration,
+}
+
+fn phase_timeout(
+    phase: Phase,
+    explicit_timeout: Option<Duration>,
+    baseline_duration: Option<Duration>,
+    minimum: Duration,
+    multiplier: f64,
+    options: &Options,
+) -> Duration {
+    const FALLBACK_TIMEOUT_SECS: u64 = 300;
+    fn warn_fallback_timeout(phase_name: &str, option: &str) {
+        warn!("An explicit {phase_name} timeout is recommended when using {option}; using {FALLBACK_TIMEOUT_SECS} seconds by default");
     }
+
+    if let Some(timeout) = explicit_timeout {
+        return timeout;
+    }
+
+    match baseline_duration {
+        Some(_) if options.in_place && phase != Phase::Test => {
+            warn_fallback_timeout(phase.name(), "--in-place");
+            Duration::from_secs(FALLBACK_TIMEOUT_SECS)
+        }
+        Some(baseline_duration) => {
+            let timeout = max(
+                minimum,
+                Duration::from_secs((baseline_duration.as_secs_f64() * multiplier).ceil() as u64),
+            );
+
+            if options.show_times {
+                info!(
+                    "Auto-set {} timeout to {}",
+                    phase.name(),
+                    humantime::format_duration(timeout)
+                );
+            }
+            timeout
+        }
+        None => {
+            warn_fallback_timeout(phase.name(), "--baseline=skip");
+            Duration::from_secs(FALLBACK_TIMEOUT_SECS)
+        }
+    }
+}
+
+fn test_timeout(baseline_duration: Option<Duration>, options: &Options) -> Duration {
+    phase_timeout(
+        Phase::Test,
+        options.test_timeout,
+        baseline_duration,
+        options.minimum_test_timeout,
+        options.test_timeout_multiplier.unwrap_or(5.0),
+        options,
+    )
+}
+
+fn build_timeout(baseline_duration: Option<Duration>, options: &Options) -> Duration {
+    phase_timeout(
+        Phase::Build,
+        options.build_timeout,
+        baseline_duration,
+        Duration::ZERO,
+        options.build_timeout_multiplier.unwrap_or(2.0),
+        options,
+    )
 }
 
 /// Test various phases of one scenario in a build dir.
@@ -226,7 +279,7 @@ fn test_scenario(
     output_mutex: &Mutex<OutputDir>,
     scenario: &Scenario,
     test_packages: &[&Package],
-    test_timeout: Duration,
+    timeouts: Timeouts,
     options: &Options,
     console: &Console,
 ) -> Result<ScenarioOutcome> {
@@ -255,8 +308,8 @@ fn test_scenario(
     for &phase in phases {
         console.scenario_phase_started(scenario, phase);
         let timeout = match phase {
-            Phase::Test => test_timeout,
-            _ => Duration::MAX,
+            Phase::Test => timeouts.test,
+            Phase::Build | Phase::Check => timeouts.build,
         };
         let phase_result = run_cargo(
             build_dir,
@@ -307,6 +360,40 @@ mod test {
     }
 
     #[test]
+    fn test_timeout_unaffected_by_in_place_build() {
+        let args = Args::parse_from(["mutants", "--timeout-multiplier", "1.5", "--in-place"]);
+        let options = Options::new(&args, &Config::default()).unwrap();
+
+        assert_eq!(
+            test_timeout(Some(Duration::from_secs(40)), &options),
+            Duration::from_secs(60),
+        );
+    }
+
+    #[test]
+    fn build_timeout_multiplier_from_option() {
+        let args = Args::parse_from(["mutants", "--build-timeout-multiplier", "1.5"]);
+        let options = Options::new(&args, &Config::default()).unwrap();
+
+        assert_eq!(options.build_timeout_multiplier, Some(1.5));
+        assert_eq!(
+            build_timeout(Some(Duration::from_secs(40)), &options),
+            Duration::from_secs(60),
+        );
+    }
+
+    #[test]
+    fn build_timeout_is_affected_by_in_place_build() {
+        let args = Args::parse_from(["mutants", "--build-timeout-multiplier", "1.5", "--in-place"]);
+        let options = Options::new(&args, &Config::default()).unwrap();
+
+        assert_eq!(
+            build_timeout(Some(Duration::from_secs(40)), &options),
+            Duration::from_secs(300),
+        );
+    }
+
+    #[test]
     fn timeout_multiplier_from_config() {
         let args = Args::parse_from(["mutants"]);
         let config = Config::from_str(indoc! {r#"
@@ -318,6 +405,22 @@ mod test {
         assert_eq!(options.test_timeout_multiplier, Some(2.0));
         assert_eq!(
             test_timeout(Some(Duration::from_secs(42)), &options),
+            Duration::from_secs(42 * 2),
+        );
+    }
+
+    #[test]
+    fn build_timeout_multiplier_from_config() {
+        let args = Args::parse_from(["mutants"]);
+        let config = Config::from_str(indoc! {r#"
+            build_timeout_multiplier = 2.0
+        "#})
+        .unwrap();
+        let options = Options::new(&args, &config).unwrap();
+
+        assert_eq!(options.build_timeout_multiplier, Some(2.0));
+        assert_eq!(
+            build_timeout(Some(Duration::from_secs(42)), &options),
             Duration::from_secs(42 * 2),
         );
     }
@@ -335,6 +438,34 @@ mod test {
     }
 
     #[test]
+    fn build_timeout_multiplier_default() {
+        let args = Args::parse_from(["mutants"]);
+        let options = Options::new(&args, &Config::default()).unwrap();
+
+        assert_eq!(options.build_timeout_multiplier, None);
+        assert_eq!(
+            build_timeout(Some(Duration::from_secs(42)), &options),
+            Duration::from_secs(42 * 2),
+        );
+    }
+
+    #[test]
+    fn timeout_from_option() {
+        let args = Args::parse_from(["mutants", "--timeout=8"]);
+        let options = Options::new(&args, &Config::default()).unwrap();
+
+        assert_eq!(options.test_timeout, Some(Duration::from_secs(8)));
+    }
+
+    #[test]
+    fn build_timeout_from_option() {
+        let args = Args::parse_from(["mutants", "--build-timeout=4"]);
+        let options = Options::new(&args, &Config::default()).unwrap();
+
+        assert_eq!(options.build_timeout, Some(Duration::from_secs(4)));
+    }
+
+    #[test]
     fn timeout_multiplier_default_with_baseline_skip() {
         // The --baseline option is not used to set the timeout but it's
         // indicative of the realistic situation.
@@ -343,5 +474,16 @@ mod test {
 
         assert_eq!(options.test_timeout_multiplier, None);
         assert_eq!(test_timeout(None, &options), Duration::from_secs(300),);
+    }
+
+    #[test]
+    fn build_timeout_multiplier_default_with_baseline_skip() {
+        // The --baseline option is not used to set the timeout but it's
+        // indicative of the realistic situation.
+        let args = Args::parse_from(["mutants", "--baseline", "skip"]);
+        let options = Options::new(&args, &Config::default()).unwrap();
+
+        assert_eq!(options.build_timeout_multiplier, None);
+        assert_eq!(build_timeout(None, &options), Duration::from_secs(300),);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -289,7 +289,7 @@ pub struct Args {
     timeout: Option<f64>,
 
     /// Test timeout multiplier (relative to base test time).
-    #[arg(long, help_heading = "Execution")]
+    #[arg(long, help_heading = "Execution", conflicts_with = "timeout")]
     timeout_multiplier: Option<f64>,
 
     /// Maximum run time for cargo build command, in seconds.
@@ -297,7 +297,7 @@ pub struct Args {
     build_timeout: Option<f64>,
 
     /// Build timeout multiplier (relative to base build time).
-    #[arg(long, help_heading = "Execution")]
+    #[arg(long, help_heading = "Execution", conflicts_with = "build_timeout")]
     build_timeout_multiplier: Option<f64>,
 
     /// Print mutations that failed to check or build.

--- a/src/main.rs
+++ b/src/main.rs
@@ -292,6 +292,14 @@ pub struct Args {
     #[arg(long, help_heading = "Execution")]
     timeout_multiplier: Option<f64>,
 
+    /// Maximum run time for cargo build command, in seconds.
+    #[arg(long, help_heading = "Execution")]
+    build_timeout: Option<f64>,
+
+    /// Build timeout multiplier (relative to base build time).
+    #[arg(long, help_heading = "Execution")]
+    build_timeout_multiplier: Option<f64>,
+
     /// Print mutations that failed to check or build.
     #[arg(long, short = 'V', help_heading = "Output")]
     unviable: bool,

--- a/src/options.rs
+++ b/src/options.rs
@@ -338,6 +338,26 @@ mod test {
     }
 
     #[test]
+    fn conflicting_timeout_options() {
+        let args = Args::try_parse_from(["mutants", "--timeout=1", "--timeout-multiplier=1"])
+            .expect_err("--timeout and --timeout-multiplier should conflict");
+        let rendered = format!("{}", args.render());
+        assert!(rendered.contains("error: the argument '--timeout <TIMEOUT>' cannot be used with '--timeout-multiplier <TIMEOUT_MULTIPLIER>'"));
+    }
+
+    #[test]
+    fn conflicting_build_timeout_options() {
+        let args = Args::try_parse_from([
+            "mutants",
+            "--build-timeout=1",
+            "--build-timeout-multiplier=1",
+        ])
+        .expect_err("--build-timeout and --build-timeout-multiplier should conflict");
+        let rendered = format!("{}", args.render());
+        assert!(rendered.contains("error: the argument '--build-timeout <BUILD_TIMEOUT>' cannot be used with '--build-timeout-multiplier <BUILD_TIMEOUT_MULTIPLIER>'"));
+    }
+
+    #[test]
     fn test_tool_from_config() {
         let config = indoc! { r#"
             test_tool = "nextest"

--- a/testdata/hang_when_mutated/src/lib.rs
+++ b/testdata/hang_when_mutated/src/lib.rs
@@ -8,6 +8,18 @@ use std::time::{Duration, Instant};
 
 static TRIGGER: AtomicBool = AtomicBool::new(false);
 
+const fn should_stop_const() -> bool {
+    true
+}
+
+/// If `should_stop_const` is mutated to return false, then this const block
+/// will hang and block compilation.
+pub const VAL: i32 = loop {
+    if should_stop_const() {
+        break 1;
+    }
+};
+
 /// If mutated to return false, the program will spin forever.
 fn should_stop() -> bool {
     if TRIGGER.load(Ordering::Relaxed) {
@@ -43,5 +55,10 @@ mod test {
         // Should do two passes: first the trigger is false but gets set,
         // then the trigger is true and the loop terminates.
         assert_eq!(super::controlled_loop(), 2);
+    }
+
+    #[test]
+    fn val_is_correct() {
+        assert_eq!(super::VAL, 1);
     }
 }

--- a/tests/snapshots/list__list_mutants_in_all_trees_as_json.snap
+++ b/tests/snapshots/list__list_mutants_in_all_trees_as_json.snap
@@ -1618,42 +1618,12 @@ expression: buf
   {
     "file": "src/lib.rs",
     "function": {
-      "function_name": "should_stop",
+      "function_name": "should_stop_const",
       "return_type": "-> bool",
       "span": {
         "end": {
           "column": 2,
-          "line": 18
-        },
-        "start": {
-          "column": 1,
-          "line": 11
-        }
-      }
-    },
-    "genre": "FnValue",
-    "package": "cargo-mutants-testdata-hang-when-mutated",
-    "replacement": "true",
-    "span": {
-      "end": {
-        "column": 10,
-        "line": 17
-      },
-      "start": {
-        "column": 5,
-        "line": 13
-      }
-    }
-  },
-  {
-    "file": "src/lib.rs",
-    "function": {
-      "function_name": "should_stop",
-      "return_type": "-> bool",
-      "span": {
-        "end": {
-          "column": 2,
-          "line": 18
+          "line": 13
         },
         "start": {
           "column": 1,
@@ -1666,12 +1636,72 @@ expression: buf
     "replacement": "false",
     "span": {
       "end": {
-        "column": 10,
-        "line": 17
+        "column": 9,
+        "line": 12
       },
       "start": {
         "column": 5,
-        "line": 13
+        "line": 12
+      }
+    }
+  },
+  {
+    "file": "src/lib.rs",
+    "function": {
+      "function_name": "should_stop",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 30
+        },
+        "start": {
+          "column": 1,
+          "line": 23
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-hang-when-mutated",
+    "replacement": "true",
+    "span": {
+      "end": {
+        "column": 10,
+        "line": 29
+      },
+      "start": {
+        "column": 5,
+        "line": 25
+      }
+    }
+  },
+  {
+    "file": "src/lib.rs",
+    "function": {
+      "function_name": "should_stop",
+      "return_type": "-> bool",
+      "span": {
+        "end": {
+          "column": 2,
+          "line": 30
+        },
+        "start": {
+          "column": 1,
+          "line": 23
+        }
+      }
+    },
+    "genre": "FnValue",
+    "package": "cargo-mutants-testdata-hang-when-mutated",
+    "replacement": "false",
+    "span": {
+      "end": {
+        "column": 10,
+        "line": 29
+      },
+      "start": {
+        "column": 5,
+        "line": 25
       }
     }
   },
@@ -1683,11 +1713,11 @@ expression: buf
       "span": {
         "end": {
           "column": 2,
-          "line": 38
+          "line": 50
         },
         "start": {
           "column": 1,
-          "line": 20
+          "line": 32
         }
       }
     },
@@ -1697,11 +1727,11 @@ expression: buf
     "span": {
       "end": {
         "column": 20,
-        "line": 37
+        "line": 49
       },
       "start": {
         "column": 5,
-        "line": 26
+        "line": 38
       }
     }
   },
@@ -1713,11 +1743,11 @@ expression: buf
       "span": {
         "end": {
           "column": 2,
-          "line": 38
+          "line": 50
         },
         "start": {
           "column": 1,
-          "line": 20
+          "line": 32
         }
       }
     },
@@ -1727,11 +1757,11 @@ expression: buf
     "span": {
       "end": {
         "column": 20,
-        "line": 37
+        "line": 49
       },
       "start": {
         "column": 5,
-        "line": 26
+        "line": 38
       }
     }
   },
@@ -1743,11 +1773,11 @@ expression: buf
       "span": {
         "end": {
           "column": 2,
-          "line": 38
+          "line": 50
         },
         "start": {
           "column": 1,
-          "line": 20
+          "line": 32
         }
       }
     },
@@ -1757,11 +1787,11 @@ expression: buf
     "span": {
       "end": {
         "column": 29,
-        "line": 33
+        "line": 45
       },
       "start": {
         "column": 28,
-        "line": 33
+        "line": 45
       }
     }
   },
@@ -1773,11 +1803,11 @@ expression: buf
       "span": {
         "end": {
           "column": 2,
-          "line": 38
+          "line": 50
         },
         "start": {
           "column": 1,
-          "line": 20
+          "line": 32
         }
       }
     },
@@ -1787,11 +1817,11 @@ expression: buf
     "span": {
       "end": {
         "column": 29,
-        "line": 33
+        "line": 45
       },
       "start": {
         "column": 28,
-        "line": 33
+        "line": 45
       }
     }
   },
@@ -1803,11 +1833,11 @@ expression: buf
       "span": {
         "end": {
           "column": 2,
-          "line": 38
+          "line": 50
         },
         "start": {
           "column": 1,
-          "line": 20
+          "line": 32
         }
       }
     },
@@ -1817,11 +1847,11 @@ expression: buf
     "span": {
       "end": {
         "column": 54,
-        "line": 33
+        "line": 45
       },
       "start": {
         "column": 53,
-        "line": 33
+        "line": 45
       }
     }
   },
@@ -1833,11 +1863,11 @@ expression: buf
       "span": {
         "end": {
           "column": 2,
-          "line": 38
+          "line": 50
         },
         "start": {
           "column": 1,
-          "line": 20
+          "line": 32
         }
       }
     },
@@ -1847,11 +1877,11 @@ expression: buf
     "span": {
       "end": {
         "column": 54,
-        "line": 33
+        "line": 45
       },
       "start": {
         "column": 53,
-        "line": 33
+        "line": 45
       }
     }
   }

--- a/tests/snapshots/list__list_mutants_in_all_trees_as_text.snap
+++ b/tests/snapshots/list__list_mutants_in_all_trees_as_text.snap
@@ -135,14 +135,15 @@ src/lib.rs:21:53: replace * with / in controlled_loop
 ## testdata/hang_when_mutated
 
 ```
-src/lib.rs:13:5: replace should_stop -> bool with true
-src/lib.rs:13:5: replace should_stop -> bool with false
-src/lib.rs:26:5: replace controlled_loop -> usize with 0
-src/lib.rs:26:5: replace controlled_loop -> usize with 1
-src/lib.rs:33:28: replace > with == in controlled_loop
-src/lib.rs:33:28: replace > with < in controlled_loop
-src/lib.rs:33:53: replace * with + in controlled_loop
-src/lib.rs:33:53: replace * with / in controlled_loop
+src/lib.rs:12:5: replace should_stop_const -> bool with false
+src/lib.rs:25:5: replace should_stop -> bool with true
+src/lib.rs:25:5: replace should_stop -> bool with false
+src/lib.rs:38:5: replace controlled_loop -> usize with 0
+src/lib.rs:38:5: replace controlled_loop -> usize with 1
+src/lib.rs:45:28: replace > with == in controlled_loop
+src/lib.rs:45:28: replace > with < in controlled_loop
+src/lib.rs:45:53: replace * with + in controlled_loop
+src/lib.rs:45:53: replace * with / in controlled_loop
 ```
 
 ## testdata/insta

--- a/tests/snapshots/main__well_tested_tree_with_short_build_timeout__caught.txt.snap
+++ b/tests/snapshots/main__well_tested_tree_with_short_build_timeout__caught.txt.snap
@@ -1,0 +1,5 @@
+---
+source: tests/main.rs
+expression: content
+---
+

--- a/tests/snapshots/main__well_tested_tree_with_short_build_timeout__missed.txt.snap
+++ b/tests/snapshots/main__well_tested_tree_with_short_build_timeout__missed.txt.snap
@@ -1,0 +1,5 @@
+---
+source: tests/main.rs
+expression: content
+---
+

--- a/tests/snapshots/main__well_tested_tree_with_short_build_timeout__timeout.txt.snap
+++ b/tests/snapshots/main__well_tested_tree_with_short_build_timeout__timeout.txt.snap
@@ -1,0 +1,70 @@
+---
+source: tests/main.rs
+expression: content
+---
+src/slices.rs:13:5: replace return_mut_slice -> &mut[usize] with Vec::leak(vec![0])
+src/numbers.rs:6:5: replace is_double -> bool with false
+src/simple_fns.rs:13:5: replace returns_42u32 -> u32 with 1
+src/arc.rs:4:5: replace return_arc -> Arc<String> with Arc::new(String::new())
+src/nested_function.rs:5:13: replace * with + in has_nested
+src/numbers.rs:6:7: replace == with != in is_double
+src/nested_function.rs:2:5: replace has_nested -> u32 with 1
+src/slices.rs:14:12: replace *= with /= in return_mut_slice
+src/simple_fns.rs:8:5: replace returns_unit with ()
+src/nested_function.rs:3:9: replace has_nested::inner -> u32 with 1
+src/simple_fns.rs:18:5: replace divisible_by_three -> bool with true
+src/simple_fns.rs:8:8: replace += with -= in returns_unit
+src/simple_fns.rs:18:7: replace % with + in divisible_by_three
+src/numbers.rs:2:9: replace * with + in double_float
+src/numbers.rs:6:12: replace * with / in is_double
+src/nested_function.rs:3:9: replace has_nested::inner -> u32 with 0
+src/numbers.rs:2:5: replace double_float -> f32 with 1.0
+src/simple_fns.rs:18:5: replace divisible_by_three -> bool with false
+src/simple_fns.rs:18:11: replace == with != in divisible_by_three
+src/simple_fns.rs:18:7: replace % with / in divisible_by_three
+src/slices.rs:14:12: replace *= with += in return_mut_slice
+src/static_item.rs:1:33: replace == with !=
+src/simple_fns.rs:27:5: replace double_string -> String with "xyzzy".into()
+src/slices.rs:4:5: replace pad -> &'a[Cow<'static, str>] with Vec::leak(Vec::new())
+src/methods.rs:17:9: replace Foo::double with ()
+src/nested_function.rs:5:13: replace * with / in has_nested
+src/result.rs:6:5: replace simple_result -> Result<&'static str, ()> with Ok("")
+src/arc.rs:4:5: replace return_arc -> Arc<String> with Arc::new("xyzzy".into())
+src/simple_fns.rs:8:8: replace += with *= in returns_unit
+src/slices.rs:13:5: replace return_mut_slice -> &mut[usize] with Vec::leak(Vec::new())
+src/methods.rs:17:16: replace *= with += in Foo::double
+src/numbers.rs:2:5: replace double_float -> f32 with -1.0
+src/slices.rs:4:5: replace pad -> &'a[Cow<'static, str>] with Vec::leak(vec![Cow::Owned("".to_owned())])
+src/slices.rs:4:5: replace pad -> &'a[Cow<'static, str>] with Vec::leak(vec![Cow::Owned("xyzzy".to_owned())])
+src/numbers.rs:2:5: replace double_float -> f32 with 0.0
+src/slices.rs:4:5: replace pad -> &'a[Cow<'static, str>] with Vec::leak(vec![Cow::Borrowed("")])
+src/numbers.rs:2:9: replace * with / in double_float
+src/numbers.rs:6:12: replace * with + in is_double
+src/methods.rs:23:9: replace <impl Display for Foo>::fmt -> fmt::Result with Ok(Default::default())
+src/traits.rs:5:9: replace Something::is_three -> bool with true
+src/slices.rs:5:20: replace < with > in pad
+src/result.rs:6:5: replace simple_result -> Result<&'static str, ()> with Ok("xyzzy")
+src/result.rs:10:10: replace < with == in error_if_negative
+src/numbers.rs:6:5: replace is_double -> bool with true
+src/methods.rs:17:16: replace *= with /= in Foo::double
+src/struct_with_lifetime.rs:15:9: replace Lex<'buf>::buf_len -> usize with 1
+src/slices.rs:4:5: replace pad -> &'a[Cow<'static, str>] with Vec::leak(vec![Cow::Borrowed("xyzzy")])
+src/nested_function.rs:2:5: replace has_nested -> u32 with 0
+src/sets.rs:4:5: replace make_a_set -> BTreeSet<String> with BTreeSet::from_iter([String::new()])
+src/slices.rs:5:20: replace < with == in pad
+src/methods.rs:29:9: replace <impl Debug for &Foo>::fmt -> fmt::Result with Ok(Default::default())
+src/struct_with_lifetime.rs:15:9: replace Lex<'buf>::buf_len -> usize with 0
+src/simple_fns.rs:27:5: replace double_string -> String with String::new()
+src/sets.rs:4:5: replace make_a_set -> BTreeSet<String> with BTreeSet::new()
+src/result.rs:10:5: replace error_if_negative -> Result<(), ()> with Ok(())
+src/result.rs:18:5: replace result_with_no_apparent_type_args -> std::fmt::Result with Ok(Default::default())
+src/simple_fns.rs:13:5: replace returns_42u32 -> u32 with 0
+src/sets.rs:4:5: replace make_a_set -> BTreeSet<String> with BTreeSet::from_iter(["xyzzy".into()])
+src/static_item.rs:1:39: replace + with -
+src/static_item.rs:1:39: replace + with *
+src/traits.rs:5:9: replace Something::is_three -> bool with false
+src/traits.rs:5:11: replace == with != in Something::is_three
+src/slices.rs:13:5: replace return_mut_slice -> &mut[usize] with Vec::leak(vec![1])
+src/inside_mod.rs:4:13: replace outer::inner::name -> &'static str with ""
+src/result.rs:10:10: replace < with > in error_if_negative
+src/inside_mod.rs:4:13: replace outer::inner::name -> &'static str with "xyzzy"

--- a/tests/snapshots/main__well_tested_tree_with_short_build_timeout__unviable.txt.snap
+++ b/tests/snapshots/main__well_tested_tree_with_short_build_timeout__unviable.txt.snap
@@ -1,0 +1,5 @@
+---
+source: tests/main.rs
+expression: content
+---
+


### PR DESCRIPTION
Fixes #322.

I mostly followed the suggested steps given in https://github.com/sourcefrog/cargo-mutants/issues/322#issuecomment-2050131753, with a couple of differences:
- I didn't find any existing unit tests for CLI options, so I didn't add any CLI unit tests for the new options
- I had to modify the rounding behaviour for timeout durations so that a very short build timeout wouldn't get rounded to zero (e.g. in the integration test of the `well_tested` tree)
- I set the default `build-timeout-multiplier` value to 2, rather than the suggested 5. I figure that since incremental builds are expected to be substantially faster than the initial build, we shouldn't expect to be waiting very long for a build.
- I didn't add a new `ScenarioOutcome` for a build timeout, mostly because in the default terminal output you can tell whether it was the build or the test that timed out by looking at the phase at the end of the line:
  - a build timeout looks like
    ```text
    TIMEOUT  src/lib.rs:12:5: replace should_stop_const -> bool with false in 1.0s build
    ``` 
  - a test timeout looks like
    ```text
    TIMEOUT  src/lib.rs:25:5: replace should_stop -> bool with false in 0.2s build + 1.0s test
    ``` 

In updating the `book/src` documentation, I felt like I would be repeating a lot of text if I were to create a new section just for build timeouts, so I rewrote the whole page to talk about both timeouts simultaneously.