### PR TITLE
Trim exclusions from Cargo package upload

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,19 +10,6 @@ homepage = "https://mutants.rs/"
 categories = ["development-tools::testing"]
 keywords = ["testing", "mutants", "cargo", "mutation-testing", "coverage"]
 rust-version = "1.74"
-exclude = [
-    ".codespell*",
-    ".markdownlint*",
-    "*.md",
-    ".devcontainer",
-    ".gitattributes",
-    ".gitignore",
-    ".github",
-    "mutants.out*",
-    ".vscode",
-    "book",
-    "testdata",
-]
 
 [package.metadata.wix]
 upgrade-guid = "CA7BFE8D-F3A7-4D1D-AE43-B7749110FA90"


### PR DESCRIPTION
This isn't enough to let the tests pass in an unpacked package, but it
should allow e.g. building the book, and I think we might as well
include them.

This is related to #355 but won't fully fix it.
