### PR TITLE
Increase timeouts proportional to the number of jobs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # cargo-mutants changelog
 
+## Unreleased
+
+- Fixed: The auto-set timeout for building mutants is now 2 times the baseline build time times the number of jobs, with a minimum of 20 seconds. This was changed because builds of mutants contend with each other for access to CPUs and may be slower than the baseline build.
+
 ## 24.5.0
 
 - Fixed: Follow `path` attributes on `mod` statements.

--- a/book/src/timeouts.md
+++ b/book/src/timeouts.md
@@ -24,8 +24,10 @@ build and test the unmodified tree (baseline).
 
 The default timeouts are:
 
-- `cargo build`/`cargo check`: 2 times the baseline build time (with a minimum of 20 seconds)
+- `cargo build`/`cargo check`: 2 times the baseline build time times the number of jobs (with a minimum of 20 seconds)
 - `cargo test`: 5 times baseline test time (with a minimum of 20 seconds)
+
+The build timeout scales with the number of jobs to reflect that cargo often spawns many jobs, and so builds run in parallel are likely to take longer than the baseline, which has no external parallelism.
 
 The minimum of 20 seconds for the test timeout can be overridden by the
 `--minimum-test-timeout` option or the `CARGO_MUTANTS_MINIMUM_TEST_TIMEOUT`

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -85,6 +85,7 @@ pub fn test_mutants(
         }
         BaselineStrategy::Skip => Timeouts::without_baseline(&options),
     };
+    debug!(?timeouts);
     let mut build_dirs = vec![build_dir];
     let jobs = max(1, min(options.jobs.unwrap_or(1), mutants.len()));
     for i in 1..jobs {

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@ mod shard;
 mod source;
 mod span;
 mod tail_file;
+mod timeouts;
 mod visit;
 mod workspace;
 

--- a/src/timeouts.rs
+++ b/src/timeouts.rs
@@ -1,0 +1,264 @@
+// Copyright 2021-2024 Martin Pool
+
+//! Calculation of timeouts for the build and test phases.
+
+use std::{cmp::max, time::Duration};
+
+use tracing::{info, warn};
+
+use crate::{
+    options::Options,
+    outcome::{Phase, ScenarioOutcome},
+};
+
+#[derive(Debug, Copy, Clone)]
+pub struct Timeouts {
+    pub build: Duration,
+    pub test: Duration,
+}
+
+impl Timeouts {
+    pub fn for_baseline(options: &Options) -> Timeouts {
+        Timeouts {
+            test: options.test_timeout.unwrap_or(Duration::MAX),
+            build: options.build_timeout.unwrap_or(Duration::MAX),
+        }
+    }
+
+    pub fn from_baseline(baseline: &ScenarioOutcome, options: &Options) -> Timeouts {
+        Timeouts {
+            build: build_timeout(
+                baseline.phase_result(Phase::Build).map(|pr| pr.duration),
+                options,
+            ),
+            test: test_timeout(
+                baseline.phase_result(Phase::Test).map(|pr| pr.duration),
+                options,
+            ),
+        }
+    }
+
+    pub fn without_baseline(options: &Options) -> Timeouts {
+        Timeouts {
+            build: build_timeout(None, options),
+            test: test_timeout(None, options),
+        }
+    }
+}
+
+const FALLBACK_TIMEOUT_SECS: u64 = 300;
+fn warn_fallback_timeout(phase_name: &str, option: &str) {
+    warn!("An explicit {phase_name} timeout is recommended when using {option}; using {FALLBACK_TIMEOUT_SECS} seconds by default");
+}
+
+fn phase_timeout(
+    phase: Phase,
+    explicit_timeout: Option<Duration>,
+    baseline_duration: Option<Duration>,
+    minimum: Duration,
+    multiplier: f64,
+    options: &Options,
+) -> Duration {
+    if let Some(timeout) = explicit_timeout {
+        return timeout;
+    }
+
+    match baseline_duration {
+        Some(_) if options.in_place && phase != Phase::Test => {
+            warn_fallback_timeout(phase.name(), "--in-place");
+            Duration::from_secs(FALLBACK_TIMEOUT_SECS)
+        }
+        Some(baseline_duration) => {
+            let timeout = max(
+                minimum,
+                Duration::from_secs((baseline_duration.as_secs_f64() * multiplier).ceil() as u64),
+            );
+
+            if options.show_times {
+                info!(
+                    "Auto-set {} timeout to {}",
+                    phase.name(),
+                    humantime::format_duration(timeout)
+                );
+            }
+            timeout
+        }
+        None => {
+            warn_fallback_timeout(phase.name(), "--baseline=skip");
+            Duration::from_secs(FALLBACK_TIMEOUT_SECS)
+        }
+    }
+}
+
+fn test_timeout(baseline_duration: Option<Duration>, options: &Options) -> Duration {
+    phase_timeout(
+        Phase::Test,
+        options.test_timeout,
+        baseline_duration,
+        options.minimum_test_timeout,
+        options.test_timeout_multiplier.unwrap_or(5.0),
+        options,
+    )
+}
+
+fn build_timeout(baseline_duration: Option<Duration>, options: &Options) -> Duration {
+    phase_timeout(
+        Phase::Build,
+        options.build_timeout,
+        baseline_duration,
+        Duration::from_secs(20),
+        options.build_timeout_multiplier.unwrap_or(2.0),
+        options,
+    )
+}
+
+#[cfg(test)]
+mod test {
+    use std::str::FromStr;
+
+    use clap::Parser;
+    use indoc::indoc;
+
+    use super::*;
+    use crate::{config::Config, Args};
+
+    #[test]
+    fn timeout_multiplier_from_option() {
+        let args = Args::parse_from(["mutants", "--timeout-multiplier", "1.5"]);
+        let options = Options::new(&args, &Config::default()).unwrap();
+
+        assert_eq!(options.test_timeout_multiplier, Some(1.5));
+        assert_eq!(
+            test_timeout(Some(Duration::from_secs(40)), &options),
+            Duration::from_secs(60),
+        );
+    }
+
+    #[test]
+    fn test_timeout_unaffected_by_in_place_build() {
+        let args = Args::parse_from(["mutants", "--timeout-multiplier", "1.5", "--in-place"]);
+        let options = Options::new(&args, &Config::default()).unwrap();
+
+        assert_eq!(
+            test_timeout(Some(Duration::from_secs(40)), &options),
+            Duration::from_secs(60),
+        );
+    }
+
+    #[test]
+    fn build_timeout_multiplier_from_option() {
+        let args = Args::parse_from(["mutants", "--build-timeout-multiplier", "1.5"]);
+        let options = Options::new(&args, &Config::default()).unwrap();
+
+        assert_eq!(options.build_timeout_multiplier, Some(1.5));
+        assert_eq!(
+            build_timeout(Some(Duration::from_secs(40)), &options),
+            Duration::from_secs(60),
+        );
+    }
+
+    #[test]
+    fn build_timeout_is_affected_by_in_place_build() {
+        let args = Args::parse_from(["mutants", "--build-timeout-multiplier", "1.5", "--in-place"]);
+        let options = Options::new(&args, &Config::default()).unwrap();
+
+        assert_eq!(
+            build_timeout(Some(Duration::from_secs(40)), &options),
+            Duration::from_secs(300),
+        );
+    }
+
+    #[test]
+    fn timeout_multiplier_from_config() {
+        let args = Args::parse_from(["mutants"]);
+        let config = Config::from_str(indoc! {r#"
+            timeout_multiplier = 2.0
+        "#})
+        .unwrap();
+        let options = Options::new(&args, &config).unwrap();
+
+        assert_eq!(options.test_timeout_multiplier, Some(2.0));
+        assert_eq!(
+            test_timeout(Some(Duration::from_secs(42)), &options),
+            Duration::from_secs(42 * 2),
+        );
+    }
+
+    #[test]
+    fn build_timeout_multiplier_from_config() {
+        let args = Args::parse_from(["mutants"]);
+        let config = Config::from_str(indoc! {r#"
+            build_timeout_multiplier = 2.0
+        "#})
+        .unwrap();
+        let options = Options::new(&args, &config).unwrap();
+
+        assert_eq!(options.build_timeout_multiplier, Some(2.0));
+        assert_eq!(
+            build_timeout(Some(Duration::from_secs(42)), &options),
+            Duration::from_secs(42 * 2),
+        );
+    }
+
+    #[test]
+    fn timeout_multiplier_default() {
+        let args = Args::parse_from(["mutants"]);
+        let options = Options::new(&args, &Config::default()).unwrap();
+
+        assert_eq!(options.test_timeout_multiplier, None);
+        assert_eq!(
+            test_timeout(Some(Duration::from_secs(42)), &options),
+            Duration::from_secs(42 * 5),
+        );
+    }
+
+    #[test]
+    fn build_timeout_multiplier_default() {
+        let args = Args::parse_from(["mutants"]);
+        let options = Options::new(&args, &Config::default()).unwrap();
+
+        assert_eq!(options.build_timeout_multiplier, None);
+        assert_eq!(
+            build_timeout(Some(Duration::from_secs(42)), &options),
+            Duration::from_secs(42 * 2),
+        );
+    }
+
+    #[test]
+    fn timeout_from_option() {
+        let args = Args::parse_from(["mutants", "--timeout=8"]);
+        let options = Options::new(&args, &Config::default()).unwrap();
+
+        assert_eq!(options.test_timeout, Some(Duration::from_secs(8)));
+    }
+
+    #[test]
+    fn build_timeout_from_option() {
+        let args = Args::parse_from(["mutants", "--build-timeout=4"]);
+        let options = Options::new(&args, &Config::default()).unwrap();
+
+        assert_eq!(options.build_timeout, Some(Duration::from_secs(4)));
+    }
+
+    #[test]
+    fn timeout_multiplier_default_with_baseline_skip() {
+        // The --baseline option is not used to set the timeout but it's
+        // indicative of the realistic situation.
+        let args = Args::parse_from(["mutants", "--baseline", "skip"]);
+        let options = Options::new(&args, &Config::default()).unwrap();
+
+        assert_eq!(options.test_timeout_multiplier, None);
+        assert_eq!(test_timeout(None, &options), Duration::from_secs(300),);
+    }
+
+    #[test]
+    fn build_timeout_multiplier_default_with_baseline_skip() {
+        // The --baseline option is not used to set the timeout but it's
+        // indicative of the realistic situation.
+        let args = Args::parse_from(["mutants", "--baseline", "skip"]);
+        let options = Options::new(&args, &Config::default()).unwrap();
+
+        assert_eq!(options.build_timeout_multiplier, None);
+        assert_eq!(build_timeout(None, &options), Duration::from_secs(300),);
+    }
+}


### PR DESCRIPTION
Fixes #365 

(Other solutions to this might be possible, but this seems like a general improvement, and setting a timeout automatically will probably always be a bit heuristic.)