### PR TITLE
Try taking out --cap-lints

### DIFF
--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -141,8 +141,7 @@ fn cargo_argv(
 /// See <https://doc.rust-lang.org/cargo/reference/environment-variables.html>
 /// <https://doc.rust-lang.org/rustc/lints/levels.html#capping-lints>
 fn rustflags() -> String {
-    let mut rustflags: Vec<String> = if let Some(rustflags) = env::var_os("CARGO_ENCODED_RUSTFLAGS")
-    {
+    let rustflags: Vec<String> = if let Some(rustflags) = env::var_os("CARGO_ENCODED_RUSTFLAGS") {
         rustflags
             .to_str()
             .expect("CARGO_ENCODED_RUSTFLAGS is not valid UTF-8")
@@ -163,7 +162,7 @@ fn rustflags() -> String {
         // TODO: build.rustflags config value.
         Vec::new()
     };
-    rustflags.push("--cap-lints=allow".to_owned());
+    // rustflags.push("--cap-lints=allow".to_owned());
     // debug!("adjusted rustflags: {:?}", rustflags);
     rustflags.join("\x1f")
 }
@@ -316,21 +315,21 @@ mod test {
         fn rustflags_with_no_environment_variables() {
             env::remove_var("RUSTFLAGS");
             env::remove_var("CARGO_ENCODED_RUSTFLAGS");
-            assert_eq!(rustflags(), "--cap-lints=allow");
+            assert_eq!(rustflags(), "");
         }
 
         #[test]
         fn rustflags_added_to_existing_encoded_rustflags() {
             env::set_var("RUSTFLAGS", "--something\x1f--else");
             env::remove_var("CARGO_ENCODED_RUSTFLAGS");
-            assert_eq!(rustflags(), "--something\x1f--else\x1f--cap-lints=allow");
+            assert_eq!(rustflags(), "--something\x1f--else");
         }
 
         #[test]
         fn rustflags_added_to_existing_rustflags() {
             env::set_var("RUSTFLAGS", "-Dwarnings");
             env::remove_var("CARGO_ENCODED_RUSTFLAGS");
-            assert_eq!(rustflags(), "-Dwarnings\x1f--cap-lints=allow");
+            assert_eq!(rustflags(), "-Dwarnings");
         }
     }
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -754,6 +754,10 @@ fn mutants_causing_tests_to_hang_are_stopped_by_manual_timeout() {
         .timeout(OUTER_TIMEOUT)
         .assert()
         .code(3); // exit_code::TIMEOUT
+    let unviable_txt = read_to_string(tmp_src_dir.path().join("mutants.out/unviable.txt"))
+        .expect("read timeout.txt");
+    let caught_txt = read_to_string(tmp_src_dir.path().join("mutants.out/caught.txt"))
+        .expect("read timeout.txt");
     let timeout_txt = read_to_string(tmp_src_dir.path().join("mutants.out/timeout.txt"))
         .expect("read timeout.txt");
     assert!(
@@ -761,10 +765,9 @@ fn mutants_causing_tests_to_hang_are_stopped_by_manual_timeout() {
         "expected text not found in:\n{timeout_txt}"
     );
     assert!(
-        timeout_txt.contains("replace should_stop_const -> bool with false"),
-        "expected text not found in:\n{timeout_txt}"
+        unviable_txt.contains("replace should_stop_const -> bool with false"),
+        "expected text not found in:\n{unviable_txt}"
     );
-    let caught_txt = read_to_string(tmp_src_dir.path().join("mutants.out/caught.txt")).unwrap();
     assert!(
         caught_txt.contains("replace should_stop -> bool with true"),
         "expected text not found in:\n{caught_txt}"
@@ -778,7 +781,7 @@ fn mutants_causing_tests_to_hang_are_stopped_by_manual_timeout() {
             .expect("read outcomes.json")
             .parse()
             .expect("parse outcomes.json");
-    assert_eq!(outcomes_json["timeout"], 2);
+    assert_eq!(outcomes_json["timeout"], 1);
 
     let phases_for_const_fn = outcomes_json["outcomes"]
         .as_array()
@@ -795,23 +798,37 @@ fn mutants_causing_tests_to_hang_are_stopped_by_manual_timeout() {
     assert_eq!(phases_for_const_fn[0]["phase"], "Build");
 }
 
+// #[test]
+// fn mutants_causing_check_to_timeout_are_stopped_by_manual_timeout() {
+//     let tmp_src_dir = copy_of_testdata("hang_when_mutated");
+//     run()
+//         .arg("mutants")
+//         .args(["--check", "--build-timeout=4"])
+//         .current_dir(tmp_src_dir.path())
+//         .env_remove("RUST_BACKTRACE")
+//         .timeout(OUTER_TIMEOUT)
+//         .assert()
+//         .code(3); // exit_code::TIMEOUT
+//     let timeout_txt = read_to_string(tmp_src_dir.path().join("mutants.out/timeout.txt"))
+//         .expect("read timeout.txt");
+//     assert!(
+//         timeout_txt.contains("replace should_stop_const -> bool with false"),
+//         "expected text not found in:\n{timeout_txt}"
+//     );
+// }
+
 #[test]
-fn mutants_causing_check_to_timeout_are_stopped_by_manual_timeout() {
+fn constfn_mutation_passes_check() {
     let tmp_src_dir = copy_of_testdata("hang_when_mutated");
-    run()
+    let cmd = run()
         .arg("mutants")
         .args(["--check", "--build-timeout=4"])
         .current_dir(tmp_src_dir.path())
         .env_remove("RUST_BACKTRACE")
         .timeout(OUTER_TIMEOUT)
         .assert()
-        .code(3); // exit_code::TIMEOUT
-    let timeout_txt = read_to_string(tmp_src_dir.path().join("mutants.out/timeout.txt"))
-        .expect("read timeout.txt");
-    assert!(
-        timeout_txt.contains("replace should_stop_const -> bool with false"),
-        "expected text not found in:\n{timeout_txt}"
-    );
+        .code(0);
+    println!("{}", String::from_utf8_lossy(&cmd.get_output().stdout));
 }
 
 #[test]


### PR DESCRIPTION
Fixes #373

(one way to fix it: just rip it out)

# TODO

- [x] Update docs
- [x] News
- [ ] Say what people should do if their crate does use `#[deny]`?
- [x] Consider adding an option to turn it back on?
