### PR TITLE
Revert to using stdlib Command, not subprocess

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,6 @@ dependencies = [
  "serde_json",
  "similar",
  "strum",
- "subprocess",
  "syn 2.0.46",
  "tempfile",
  "time",
@@ -1272,16 +1271,6 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 2.0.46",
-]
-
-[[package]]
-name = "subprocess"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "055cf3ebc2981ad8f0a5a17ef6652f652d87831f79fddcba2ac57bcb9a0aa407"
-dependencies = [
- "libc",
- "winapi 0.3.9",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ regex = "1.10"
 serde_json = "1.0.117"
 similar = "2.1"
 strum = { version = "0.26", features = ["derive"] }
-subprocess = "0.2.8"
 tempfile = "3.4"
 time = "0.3"
 toml = "0.8"

--- a/src/process.rs
+++ b/src/process.rs
@@ -122,6 +122,7 @@ impl Process {
     /// Blocks until the subprocess is terminated and then returns the exit status.
     ///
     /// The status might not be Timeout if this raced with a normal exit.
+    #[mutants::skip] // would leak processes from tests if skipped
     fn terminate(&mut self) -> Result<()> {
         let _span = span!(Level::DEBUG, "terminate_child", pid = self.child.id()).entered();
         debug!("terminating child process");

--- a/src/process.rs
+++ b/src/process.rs
@@ -2,21 +2,19 @@
 
 //! Manage a subprocess, with polling, timeouts, termination, and so on.
 //!
-//! This module is above the external `subprocess` crate, but has no
-//! knowledge of whether it's running Cargo or potentially something else.
-//!
 //! On Unix, the subprocess runs as its own process group, so that any
 //! grandchild processes are also signalled if it's interrupted.
 
-use std::ffi::OsString;
-use std::io::Read;
+use std::ffi::OsStr;
+#[cfg(unix)]
+use std::os::unix::process::{CommandExt, ExitStatusExt};
+use std::process::{Child, Command, Stdio};
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 
-use anyhow::{anyhow, Context};
+use anyhow::{bail, Context};
 use camino::Utf8Path;
 use serde::Serialize;
-use subprocess::{ExitStatus, Popen, PopenConfig, Redirection};
 use tracing::{debug, debug_span, error, span, trace, warn, Level};
 
 use crate::console::Console;
@@ -24,14 +22,11 @@ use crate::interrupt::check_interrupted;
 use crate::log_file::LogFile;
 use crate::Result;
 
-/// How long to wait for metadata-only Cargo commands.
-const METADATA_TIMEOUT: Duration = Duration::from_secs(20);
-
 /// How frequently to check if a subprocess finished.
 const WAIT_POLL_INTERVAL: Duration = Duration::from_millis(50);
 
 pub struct Process {
-    child: Popen,
+    child: Child,
     start: Instant,
     timeout: Duration,
 }
@@ -72,23 +67,20 @@ impl Process {
         let quoted_argv = cheap_shell_quote(argv);
         log_file.message(&quoted_argv);
         debug!(%quoted_argv, "start process");
-        let mut os_env = PopenConfig::current_env();
-        os_env.extend(
-            env.iter()
-                .map(|(k, v)| (OsString::from(k), OsString::from(v))),
-        );
-        let child = Popen::create(
-            argv,
-            PopenConfig {
-                stdin: Redirection::None,
-                stdout: Redirection::File(log_file.open_append()?),
-                stderr: Redirection::Merge,
-                cwd: Some(cwd.as_os_str().to_owned()),
-                env: Some(os_env),
-                ..setpgid_on_unix()
-            },
-        )
-        .with_context(|| format!("failed to spawn {}", argv.join(" ")))?;
+        let os_env = env.iter().map(|(k, v)| (OsStr::new(k), OsStr::new(v)));
+        let mut child = Command::new(&argv[0]);
+        child
+            .args(&argv[1..])
+            .envs(os_env)
+            .stdin(Stdio::null())
+            .stdout(log_file.open_append()?)
+            .stderr(log_file.open_append()?)
+            .current_dir(cwd);
+        #[cfg(unix)]
+        child.process_group(0);
+        let child = child
+            .spawn()
+            .with_context(|| format!("failed to spawn {}", argv.join(" ")))?;
         Ok(Process {
             child,
             start,
@@ -108,13 +100,19 @@ impl Process {
             debug!("interrupted, terminating child process...");
             self.terminate()?;
             Err(e)
-        } else if let Some(status) = self.child.poll() {
-            match status {
-                _ if status.success() => Ok(Some(ProcessStatus::Success)),
-                ExitStatus::Exited(code) => Ok(Some(ProcessStatus::Failure(code))),
-                ExitStatus::Signaled(signal) => Ok(Some(ProcessStatus::Signalled(signal))),
-                ExitStatus::Undetermined | ExitStatus::Other(_) => Ok(Some(ProcessStatus::Other)),
+        } else if let Some(status) = self.child.try_wait()? {
+            if let Some(code) = status.code() {
+                if code == 0 {
+                    return Ok(Some(ProcessStatus::Success));
+                } else {
+                    return Ok(Some(ProcessStatus::Failure(code as u32)));
+                }
             }
+            #[cfg(unix)]
+            if let Some(signal) = status.signal() {
+                return Ok(Some(ProcessStatus::Signalled(signal as u8)));
+            }
+            Ok(Some(ProcessStatus::Other))
         } else {
             Ok(None)
         }
@@ -126,31 +124,13 @@ impl Process {
     ///
     /// The status might not be Timeout if this raced with a normal exit.
     fn terminate(&mut self) -> Result<()> {
-        let _span = span!(Level::DEBUG, "terminate_child", pid = self.child.pid()).entered();
+        let _span = span!(Level::DEBUG, "terminate_child", pid = self.child.id()).entered();
         debug!("terminating child process");
         terminate_child_impl(&mut self.child)?;
         trace!("wait for child after termination");
-        if let Some(exit_status) = self
-            .child
-            .wait_timeout(Duration::from_secs(10))
-            .context("wait for child after terminating pgroup")?
-        {
-            debug!("terminated child exit status {exit_status:?}");
-        } else {
-            warn!("child did not exit after termination");
-            let kill_result = self.child.kill();
-            warn!("force kill child: {:?}", kill_result);
-            if kill_result.is_ok() {
-                if let Ok(Some(exit_status)) = self
-                    .child
-                    .wait_timeout(Duration::from_secs(10))
-                    .context("wait for child after force kill")
-                {
-                    debug!("force kill child exit status {exit_status:?}");
-                } else {
-                    warn!("child did not exit after force kill");
-                }
-            }
+        match self.child.wait() {
+            Err(err) => debug!(?err, "Failed to wait for child after termination"),
+            Ok(exit) => debug!("terminated child exit status {exit:?}"),
         }
         Ok(())
     }
@@ -159,11 +139,11 @@ impl Process {
 #[cfg(unix)]
 #[allow(unknown_lints, clippy::needless_pass_by_ref_mut)] // To match Windows
 #[mutants::skip] // hard to exercise the ESRCH edge case
-fn terminate_child_impl(child: &mut Popen) -> Result<()> {
+fn terminate_child_impl(child: &mut Child) -> Result<()> {
     use nix::errno::Errno;
     use nix::sys::signal::{killpg, Signal};
 
-    let pid = nix::unistd::Pid::from_raw(child.pid().expect("child has a pid").try_into().unwrap());
+    let pid = nix::unistd::Pid::from_raw(child.id().try_into().unwrap());
     match killpg(pid, Signal::SIGTERM) {
         Ok(()) => Ok(()),
         Err(Errno::ESRCH) => {
@@ -175,22 +155,15 @@ fn terminate_child_impl(child: &mut Popen) -> Result<()> {
         Err(errno) => {
             let message = format!("failed to terminate child: {errno}");
             warn!("{}", message);
-            Err(anyhow!(message))
+            bail!(message);
         }
     }
 }
 
-// We do not yet have a way to mutate this only on Windows, and I mostly test on Unix, so it's just skipped for now.
-#[mutants::skip]
-#[cfg(not(unix))]
-fn terminate_child_impl(child: &mut Popen) -> Result<()> {
-    if let Err(e) = child.terminate() {
-        // most likely we raced and it's already gone
-        let message = format!("failed to terminate child: {}", e);
-        warn!("{}", message);
-        return Err(anyhow!(message));
-    }
-    Ok(())
+#[cfg(windows)]
+#[mutants::skip] // hard to exercise the ESRCH edge case
+fn terminate_child_impl(child: &mut Child) -> Result<()> {
+    child.kill().context("Kill child")
 }
 
 /// The result of running a single child process.
@@ -222,21 +195,6 @@ impl ProcessStatus {
     }
 }
 
-#[cfg(unix)]
-#[mutants::skip] // It's hard to observe if this is broken: we'd expect children to leak.
-fn setpgid_on_unix() -> PopenConfig {
-    PopenConfig {
-        setpgid: true,
-        ..Default::default()
-    }
-}
-
-#[mutants::skip] // Has no effect, so can't be tested.
-#[cfg(not(unix))]
-fn setpgid_on_unix() -> PopenConfig {
-    Default::default()
-}
-
 /// Run a command and return its stdout output as a string.
 ///
 /// If the command exits non-zero, the error includes any messages it wrote to stderr.
@@ -246,46 +204,18 @@ pub fn get_command_output(argv: &[&str], cwd: &Utf8Path) -> Result<String> {
     // TODO: Perhaps redirect to files so this doesn't jam if there's a lot of output.
     // For the commands we use this for today, which only produce small output, it's OK.
     let _span = debug_span!("get_command_output", argv = ?argv).entered();
-    let mut child = Popen::create(
-        argv,
-        PopenConfig {
-            stdin: Redirection::None,
-            stdout: Redirection::Pipe,
-            stderr: Redirection::Pipe,
-            cwd: Some(cwd.as_os_str().to_owned()),
-            ..Default::default()
-        },
-    )
-    .with_context(|| format!("failed to spawn {argv:?}"))?;
-    match child.wait_timeout(METADATA_TIMEOUT) {
-        Err(e) => {
-            let message = format!("failed to wait for {argv:?}: {e}");
-            return Err(anyhow!(message));
-        }
-        Ok(None) => {
-            let message = format!("{argv:?} timed out",);
-            return Err(anyhow!(message));
-        }
-        Ok(Some(status)) if status.success() => {}
-        Ok(Some(status)) => {
-            let mut stderr = String::new();
-            let _ = child
-                .stderr
-                .take()
-                .expect("child has stderr")
-                .read_to_string(&mut stderr);
-            error!("child failed with status {status:?}: {stderr}");
-            let message = format!("{argv:?} failed with status {status:?}: {stderr}");
-            return Err(anyhow!(message));
-        }
+    let output = Command::new(argv[0])
+        .args(&argv[1..])
+        .stderr(Stdio::inherit())
+        .current_dir(cwd)
+        .output()
+        .with_context(|| format!("failed to spawn {argv:?}"))?;
+    let exit = output.status;
+    if !exit.success() {
+        error!(?exit, "Child failed");
+        bail!("Child failed with status {exit:?}: {argv:?}");
     }
-    let mut stdout = String::new();
-    child
-        .stdout
-        .take()
-        .expect("child has stdout")
-        .read_to_string(&mut stdout)
-        .context("failed to read child stdout")?;
+    let stdout = String::from_utf8(output.stdout).context("Child output is not UTF-8")?;
     debug!("output: {}", stdout.trim());
     Ok(stdout)
 }


### PR DESCRIPTION
Rust stdlib now has support for setting the process group on Unix.

Simplify timeouts waiting for children: just wait, without timing out and without sending a second signal. If the whole thing hangs, the user or a higher-level timout can stop it.

Aside from dropping a not-really-needed dependency, this should allow us to use jobservers.