### PR TITLE
fix: Don't error on diffs mentioning binary files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - New: cargo-mutants starts a GNU jobserver, shared across all children, so that running multiple `--jobs` does not spawn an excessive number of compiler processes. The jobserver is on by default and can be turned off with `--jobserver false`.
 
+- Fixed: Don't error on diffs containing a "Binary files differ" message.
+
 ## 24.7.1
 
 - Changed: No build timeouts by default. Previously, cargo-mutants set a default build timeout based on the baseline build, but experience showed that this would sometimes make builds flaky, because build times can be quite variable. If mutants cause builds to hang, then you can still set a timeout using `--build-timeout` or `--build-timeout-multiplier`.

--- a/src/in_diff.rs
+++ b/src/in_diff.rs
@@ -23,7 +23,7 @@ pub fn diff_filter(mutants: Vec<Mutant>, diff_text: &str) -> Result<Vec<Mutant>>
     // the moment; this could be removed if it's fixed in that crate.
     let fixed_diff = diff_text
         .lines()
-        .filter(|line| !(line.starts_with("Binary files ") && line.ends_with("differ")))
+        .filter(|line| !(line.starts_with("Binary files ")))
         .chain(once(""))
         .join("\n");
 

--- a/tests/in_diff.rs
+++ b/tests/in_diff.rs
@@ -70,6 +70,24 @@ fn list_mutants_changed_in_diff1() {
 }
 
 #[test]
+fn binary_diff_is_not_an_error_and_matches_nothing() {
+    // From https://github.com/sourcefrog/cargo-mutants/issues/391
+    let mut diff_file = NamedTempFile::new().unwrap();
+    diff_file.write_all(b"Binary files a/test-renderers/expected/renderers/fog-None-wgpu.png and b/test-renderers/expected/renderers/fog-None-wgpu.png differ\n").unwrap();
+    let tmp = copy_of_testdata("diff1");
+    run()
+        .args(["mutants", "--no-shuffle", "-d"])
+        .arg(tmp.path())
+        .arg("--in-diff")
+        .arg(diff_file.path())
+        .arg("--list")
+        .assert()
+        .success()
+        .stdout("")
+        .stderr(predicate::str::contains("diff file is empty"));
+}
+
+#[test]
 fn empty_diff_is_not_an_error_and_matches_nothing() {
     let diff_file = NamedTempFile::new().unwrap();
     let tmp = copy_of_testdata("diff1");


### PR DESCRIPTION
The `patch` crate doesn't understand them, so just filter them out.

Fixes #391