### PR TITLE
Don't pass --cargo-arg=--profile in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -160,7 +160,6 @@ jobs:
           install cargo-mutants ~/.cargo/bin/
       - name: Mutants in-diff
         # Normally this would have --in-place, but for the sake of exercising more cases, it does not.
-        # TODO: Pass --profile=mutants when supported
         run: >
           cargo mutants --no-shuffle -vV --in-diff git.diff --test-tool=${{matrix.test_tool}} --timeout=500 --build-timeout=500
       - name: Archive mutants.out
@@ -201,7 +200,6 @@ jobs:
           cargo mutants --no-shuffle -vV --shard ${{ matrix.shard }}/10
           --test-tool ${{ matrix.test_tool }} --baseline=skip --timeout=500
           --build-timeout=500 --in-place
-          --cargo-arg=--profile=mutants
       - name: Archive mutants.out
         uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
This is now configured from mutants.toml, so we should not also pass it as a cargo-arg

Fixes #409
