### PR TITLE
Self-tests can run from a simple string

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -190,7 +190,16 @@ Therefore when running `rustc` we configure all warnings off, with `--cap-lints`
 
 ## Testing
 
-Cargo-mutants is primarily tested on its public interface, which is the command line. These tests live in `tests/cli` and generally have the form of:
+Testing cargo-mutants is of course important: both so that it works reliably and also so that it's a good example of a well-tested project that should have few missed mutants.
+
+### integration and unit tests
+
+The tests have a combination of:
+
+1. Rust "unit" tests run in-process, declared in `mod test{}` within various files in `src`.
+2. Rust "integration" tests in the `tests` directory that actually run `cargo-mutants` as a subprocess and that test its overall behavior.
+
+The integration tests are in some sense more realistic because they drive the same interface as real users, but they will also typically be slower because they spawn subprocesses. As a result, my general idea is to have at least basic coverage of each feature with an integration test, and then to fill in the other cases with unit tests.
 
 1. Make a copy of a `testdata` tree, so that it's not accidentally modified.
 2. Run a `cargo-mutants` command on it.
@@ -212,15 +221,15 @@ To manage test time:
 
 ### `testdata` trees
 
-The primary means of testing is Rust source trees under `testdata`: you can copy an existing tree and modify it to show the new behavior that you want to test.
+Many tests run against trees under `testdata`.
 
-A selection of test trees are available for testing different scenarios. If there is an existing suitable tree, please use it. If you need to test a situation that is not covered yet, please add a new tree.
+These have been "disarmed" by renaming `Cargo.toml` to `Cargo_test.toml`, so `cargo` won't normally run them, or see them as part of the main workspace. (See <https://github.com/sourcefrog/cargo-mutants/issues/355> for context.)
+
+Tests should always run against a copy of these trees using `copy_of_testdata`, to make sure their work has no side effects on the main tree.
 
 Please describe the purpose of the testdata tree inside the tree, either in `Cargo.toml` or a `README.md` file.
 
 To make a new tree you can copy an existing tree, but make sure to change the package name in its `Cargo.toml`.
-
-All the trees need to be excluded from the overall workspace in the top-level `Cargo.toml`.
 
 ### `--list` tests
 
@@ -228,13 +237,9 @@ There is a general test that runs `cargo mutants --list` on each tree and compar
 
 Many features can be tested adequately by only looking at the list of mutants produced, with no need to actually test the mutants. In this case the generic list tests might be enough.
 
-### Unit tests
-
-Although we primarily want to test the public interface (which is the command line), unit tests can be added in a `mod test {}` within the source tree for any behavior that is inconvenient or overly slow to exercise from the command line.
-
 ### Nextest tests
 
-cargo-mutants tests require `nextest` to be installed.
+cargo-mutants tests require `nextest` to be installed so that we can test the integration.
 
 ## UI Style
 

--- a/src/mutate.rs
+++ b/src/mutate.rs
@@ -237,8 +237,9 @@ mod test {
     use indoc::indoc;
     use itertools::Itertools;
     use pretty_assertions::assert_eq;
-    use test_util::copy_of_testdata;
 
+    use crate::test_util::copy_of_testdata;
+    use crate::visit::mutate_source_str;
     use crate::*;
 
     #[test]
@@ -324,6 +325,23 @@ mod test {
         replace * with / in controlled_loop
         "###
         );
+    }
+
+    #[test]
+    fn always_skip_constructors_called_new() {
+        let code = indoc! { r#"
+            struct S {
+                x: i32,
+            }
+
+            impl S {
+                fn new(x: i32) -> Self {
+                    Self { x }
+                }
+            }
+        "# };
+        let mutants = mutate_source_str(code, &Options::default()).unwrap();
+        assert_eq!(mutants, []);
     }
 
     #[test]

--- a/src/options.rs
+++ b/src/options.rs
@@ -11,6 +11,7 @@ use globset::GlobSet;
 use regex::RegexSet;
 use serde::Deserialize;
 use strum::{Display, EnumString};
+use syn::Expr;
 use tracing::warn;
 
 use crate::config::Config;
@@ -306,6 +307,17 @@ impl Options {
         } else {
             &[Phase::Build, Phase::Test]
         }
+    }
+
+    /// Return the syn ASTs for the error values, which should be inserted as return values
+    /// from functions returning `Result`.
+    pub(crate) fn parsed_error_exprs(&self) -> Result<Vec<Expr>> {
+        self.error_values
+            .iter()
+            .map(|e| {
+                syn::parse_str(e).with_context(|| format!("Failed to parse error value {e:?}"))
+            })
+            .collect()
     }
 }
 

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -259,12 +259,9 @@ fn packages_from_metadata(metadata: &Metadata) -> Result<Vec<Package>> {
 /// Find all the top source files for selected packages.
 fn top_sources(root: &Utf8Path, packages: &[Package]) -> Result<Vec<SourceFile>> {
     let mut sources = Vec::new();
-    for Package {
-        name, top_sources, ..
-    } in packages
-    {
-        for source_path in top_sources {
-            sources.extend(SourceFile::new(root, source_path.to_owned(), name, true)?);
+    for package in packages {
+        for source_path in &package.top_sources {
+            sources.extend(SourceFile::load(root, source_path, &package.name, true)?);
         }
     }
     Ok(sources)


### PR DESCRIPTION
Many of the tests are concerned with what mutations are generated from some source code, given some options. For many of these we don't really need a source tree on disk and certainly not to run cargo: it's enough just to have the one file we're mutating.

This adds a new API making just the mutation code accessible to unit tests.

This ought to make tests faster to run, and potentially easier to write because they can be more self contained. 

Fixes #433 