### PR TITLE
changed: Traits in mutant names include the path

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # cargo-mutants changelog
 
+## Unreleased
+
+- Changed: Show more type parameters in mutant names, like `impl From<&str> for Foo` rather than `impl From for Foo`.
+
 ## 25.0.0
 
 - Better estimation of time remaining, based on the time taken to test mutants so far, excluding the time for the baseline.
@@ -21,6 +25,8 @@
 - Changed: The arguments of calls to functions or methods named `with_capacity` are not mutated by default. This can be turned off with `--skip-calls-defaults=false` on the command line or `skip_calls_defaults = false` in `.cargo/mutants.toml`.
 
 - New: `--skip-calls=NAME,NAME` on the command line or `skip_calls = [NAMES..]` in `.cargo/mutants.toml` allows configuring other functions whose calls should never be mutated.
+
+- Changed: The mutant name for trait impls now includes the path of the trait as it occurs in the source file: for example `impl fmt::Display for Foo`.
 
 ## 24.11.0
 

--- a/tests/snapshots/list__list_mutants_in_all_trees_as_json.snap
+++ b/tests/snapshots/list__list_mutants_in_all_trees_as_json.snap
@@ -6628,7 +6628,7 @@ expression: buf
   {
     "file": "src/methods.rs",
     "function": {
-      "function_name": "<impl Display for Foo>::fmt",
+      "function_name": "<impl fmt::Display for Foo>::fmt",
       "return_type": "-> fmt::Result",
       "span": {
         "end": {
@@ -6658,7 +6658,7 @@ expression: buf
   {
     "file": "src/methods.rs",
     "function": {
-      "function_name": "<impl Debug for &Foo>::fmt",
+      "function_name": "<impl fmt::Debug for &Foo>::fmt",
       "return_type": "-> fmt::Result",
       "span": {
         "end": {
@@ -9842,5 +9842,3 @@ expression: buf
   }
 ]
 ```
-
-

--- a/tests/snapshots/list__list_mutants_in_all_trees_as_text.snap
+++ b/tests/snapshots/list__list_mutants_in_all_trees_as_text.snap
@@ -426,8 +426,8 @@ src/inside_mod.rs:4:13: replace outer::inner::name -> &'static str with "xyzzy"
 src/methods.rs:17:9: replace Foo::double with ()
 src/methods.rs:17:16: replace *= with += in Foo::double
 src/methods.rs:17:16: replace *= with /= in Foo::double
-src/methods.rs:23:9: replace <impl Display for Foo>::fmt -> fmt::Result with Ok(Default::default())
-src/methods.rs:29:9: replace <impl Debug for &Foo>::fmt -> fmt::Result with Ok(Default::default())
+src/methods.rs:23:9: replace <impl fmt::Display for Foo>::fmt -> fmt::Result with Ok(Default::default())
+src/methods.rs:29:9: replace <impl fmt::Debug for &Foo>::fmt -> fmt::Result with Ok(Default::default())
 src/nested_function.rs:2:5: replace has_nested -> u32 with 0
 src/nested_function.rs:2:5: replace has_nested -> u32 with 1
 src/nested_function.rs:3:9: replace has_nested::inner -> u32 with 0
@@ -545,5 +545,3 @@ main2/src/main.rs:10:5: replace triple_3 -> i32 with 0
 main2/src/main.rs:10:5: replace triple_3 -> i32 with 1
 main2/src/main.rs:10:5: replace triple_3 -> i32 with -1
 ```
-
-

--- a/tests/snapshots/main__well_tested_tree_check_only.snap
+++ b/tests/snapshots/main__well_tested_tree_check_only.snap
@@ -24,8 +24,8 @@ ok       src/inside_mod.rs:4:13: replace outer::inner::name -> &'static str with
 ok       src/methods.rs:17:9: replace Foo::double with ()
 ok       src/methods.rs:17:16: replace *= with += in Foo::double
 ok       src/methods.rs:17:16: replace *= with /= in Foo::double
-ok       src/methods.rs:23:9: replace <impl Display for Foo>::fmt -> fmt::Result with Ok(Default::default())
-ok       src/methods.rs:29:9: replace <impl Debug for &Foo>::fmt -> fmt::Result with Ok(Default::default())
+ok       src/methods.rs:23:9: replace <impl fmt::Display for Foo>::fmt -> fmt::Result with Ok(Default::default())
+ok       src/methods.rs:29:9: replace <impl fmt::Debug for &Foo>::fmt -> fmt::Result with Ok(Default::default())
 ok       src/nested_function.rs:2:5: replace has_nested -> u32 with 0
 ok       src/nested_function.rs:2:5: replace has_nested -> u32 with 1
 ok       src/nested_function.rs:3:9: replace has_nested::inner -> u32 with 0

--- a/tests/snapshots/main__well_tested_tree_finds_no_problems.snap
+++ b/tests/snapshots/main__well_tested_tree_finds_no_problems.snap
@@ -24,8 +24,8 @@ caught   src/inside_mod.rs:4:13: replace outer::inner::name -> &'static str with
 caught   src/methods.rs:17:9: replace Foo::double with ()
 caught   src/methods.rs:17:16: replace *= with += in Foo::double
 caught   src/methods.rs:17:16: replace *= with /= in Foo::double
-caught   src/methods.rs:23:9: replace <impl Display for Foo>::fmt -> fmt::Result with Ok(Default::default())
-caught   src/methods.rs:29:9: replace <impl Debug for &Foo>::fmt -> fmt::Result with Ok(Default::default())
+caught   src/methods.rs:23:9: replace <impl fmt::Display for Foo>::fmt -> fmt::Result with Ok(Default::default())
+caught   src/methods.rs:29:9: replace <impl fmt::Debug for &Foo>::fmt -> fmt::Result with Ok(Default::default())
 caught   src/nested_function.rs:2:5: replace has_nested -> u32 with 0
 caught   src/nested_function.rs:2:5: replace has_nested -> u32 with 1
 caught   src/nested_function.rs:3:9: replace has_nested::inner -> u32 with 0

--- a/tests/snapshots/main__well_tested_tree_finds_no_problems__caught.txt.snap
+++ b/tests/snapshots/main__well_tested_tree_finds_no_problems__caught.txt.snap
@@ -22,8 +22,8 @@ src/inside_mod.rs:4:13: replace outer::inner::name -> &'static str with "xyzzy"
 src/methods.rs:17:9: replace Foo::double with ()
 src/methods.rs:17:16: replace *= with += in Foo::double
 src/methods.rs:17:16: replace *= with /= in Foo::double
-src/methods.rs:23:9: replace <impl Display for Foo>::fmt -> fmt::Result with Ok(Default::default())
-src/methods.rs:29:9: replace <impl Debug for &Foo>::fmt -> fmt::Result with Ok(Default::default())
+src/methods.rs:23:9: replace <impl fmt::Display for Foo>::fmt -> fmt::Result with Ok(Default::default())
+src/methods.rs:29:9: replace <impl fmt::Debug for &Foo>::fmt -> fmt::Result with Ok(Default::default())
 src/nested_function.rs:2:5: replace has_nested -> u32 with 0
 src/nested_function.rs:2:5: replace has_nested -> u32 with 1
 src/nested_function.rs:3:9: replace has_nested::inner -> u32 with 0

--- a/tests/util/snapshots/list__util__list_mutants_json_well_tested.snap
+++ b/tests/util/snapshots/list__util__list_mutants_json_well_tested.snap
@@ -606,7 +606,7 @@ expression: "String::from_utf8_lossy(&output.stdout)"
   {
     "file": "src/methods.rs",
     "function": {
-      "function_name": "<impl Display for Foo>::fmt",
+      "function_name": "<impl fmt::Display for Foo>::fmt",
       "return_type": "-> fmt::Result",
       "span": {
         "end": {
@@ -636,7 +636,7 @@ expression: "String::from_utf8_lossy(&output.stdout)"
   {
     "file": "src/methods.rs",
     "function": {
-      "function_name": "<impl Debug for &Foo>::fmt",
+      "function_name": "<impl fmt::Debug for &Foo>::fmt",
       "return_type": "-> fmt::Result",
       "span": {
         "end": {

--- a/tests/util/snapshots/list__util__list_mutants_well_tested.snap
+++ b/tests/util/snapshots/list__util__list_mutants_well_tested.snap
@@ -22,8 +22,8 @@ src/inside_mod.rs:4:13: replace outer::inner::name -> &'static str with "xyzzy"
 src/methods.rs:17:9: replace Foo::double with ()
 src/methods.rs:17:16: replace *= with += in Foo::double
 src/methods.rs:17:16: replace *= with /= in Foo::double
-src/methods.rs:23:9: replace <impl Display for Foo>::fmt -> fmt::Result with Ok(Default::default())
-src/methods.rs:29:9: replace <impl Debug for &Foo>::fmt -> fmt::Result with Ok(Default::default())
+src/methods.rs:23:9: replace <impl fmt::Display for Foo>::fmt -> fmt::Result with Ok(Default::default())
+src/methods.rs:29:9: replace <impl fmt::Debug for &Foo>::fmt -> fmt::Result with Ok(Default::default())
 src/nested_function.rs:2:5: replace has_nested -> u32 with 0
 src/nested_function.rs:2:5: replace has_nested -> u32 with 1
 src/nested_function.rs:3:9: replace has_nested::inner -> u32 with 0

--- a/tests/util/snapshots/list__util__list_mutants_well_tested_exclude_name_filter.snap
+++ b/tests/util/snapshots/list__util__list_mutants_well_tested_exclude_name_filter.snap
@@ -22,8 +22,8 @@ src/inside_mod.rs:4:13: replace outer::inner::name -> &'static str with "xyzzy"
 src/methods.rs:17:9: replace Foo::double with ()
 src/methods.rs:17:16: replace *= with += in Foo::double
 src/methods.rs:17:16: replace *= with /= in Foo::double
-src/methods.rs:23:9: replace <impl Display for Foo>::fmt -> fmt::Result with Ok(Default::default())
-src/methods.rs:29:9: replace <impl Debug for &Foo>::fmt -> fmt::Result with Ok(Default::default())
+src/methods.rs:23:9: replace <impl fmt::Display for Foo>::fmt -> fmt::Result with Ok(Default::default())
+src/methods.rs:29:9: replace <impl fmt::Debug for &Foo>::fmt -> fmt::Result with Ok(Default::default())
 src/nested_function.rs:2:5: replace has_nested -> u32 with 0
 src/nested_function.rs:2:5: replace has_nested -> u32 with 1
 src/nested_function.rs:3:9: replace has_nested::inner -> u32 with 0


### PR DESCRIPTION
For example `impl fmt::Display for Foo`.