### PR TITLE
refactor: Cleaner separation of OS-specific code

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -197,6 +197,7 @@ jobs:
         run: >
           cargo mutants --no-shuffle -vV --in-diff git.diff
           --test-tool=${{matrix.test_tool}} --timeout=500 --build-timeout=500
+          --exclude=windows.rs
       - name: Archive mutants.out
         uses: actions/upload-artifact@v4
         if: always()
@@ -234,7 +235,7 @@ jobs:
         run: >
           cargo mutants --no-shuffle -vV --shard ${{ matrix.shard }}/10
           --test-tool ${{ matrix.test_tool }} --baseline=skip --timeout=500
-          --build-timeout=500 --in-place
+          --build-timeout=500 --in-place --exclude=windows.rs
       - name: Archive mutants.out
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -197,7 +197,7 @@ jobs:
         run: >
           cargo mutants --no-shuffle -vV --in-diff git.diff
           --test-tool=${{matrix.test_tool}} --timeout=500 --build-timeout=500
-          --exclude=windows.rs
+          --exclude=windows.rs --exclude=console.rs
       - name: Archive mutants.out
         uses: actions/upload-artifact@v4
         if: always()
@@ -236,6 +236,7 @@ jobs:
           cargo mutants --no-shuffle -vV --shard ${{ matrix.shard }}/10
           --test-tool ${{ matrix.test_tool }} --baseline=skip --timeout=500
           --build-timeout=500 --in-place --exclude=windows.rs
+          --exclude=console.rs
       - name: Archive mutants.out
         uses: actions/upload-artifact@v4
         if: always()

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -16,7 +16,7 @@ use crate::options::{Options, TestTool};
 use crate::outcome::{Phase, PhaseResult};
 use crate::output::ScenarioOutput;
 use crate::package::PackageSelection;
-use crate::process::{Process, ProcessStatus};
+use crate::process::{Exit, Process};
 use crate::Result;
 
 /// Run cargo build, check, or test.
@@ -56,7 +56,7 @@ pub fn run_cargo(
     )?;
     check_interrupted()?;
     debug!(?process_status, elapsed = ?start.elapsed());
-    if let ProcessStatus::Failure(code) = process_status {
+    if let Exit::Failure(code) = process_status {
         // 100 "one or more tests failed" from <https://docs.rs/nextest-metadata/latest/nextest_metadata/enum.NextestExitCode.html>;
         // I'm not addind a dependency to just get one integer.
         if argv[1] == "nextest" && code != 100 {

--- a/src/outcome.rs
+++ b/src/outcome.rs
@@ -14,7 +14,7 @@ use serde::Serializer;
 use tracing::warn;
 
 use crate::console::plural;
-use crate::process::ProcessStatus;
+use crate::process::Exit;
 use crate::*;
 
 /// What phase of running a scenario.
@@ -193,7 +193,7 @@ impl ScenarioOutcome {
         self.phase_results.last().unwrap().phase
     }
 
-    pub fn last_phase_result(&self) -> ProcessStatus {
+    pub fn last_phase_result(&self) -> Exit {
         self.phase_results.last().unwrap().process_status
     }
 
@@ -284,7 +284,7 @@ pub struct PhaseResult {
     /// How long did it take?
     pub duration: Duration,
     /// Did it succeed?
-    pub process_status: ProcessStatus,
+    pub process_status: Exit,
     /// What command was run, as an argv list.
     pub argv: Vec<String>,
 }
@@ -324,7 +324,7 @@ pub enum SummaryOutcome {
 mod test {
     use std::time::Duration;
 
-    use crate::process::ProcessStatus;
+    use crate::process::Exit;
 
     use super::{Phase, PhaseResult, Scenario, ScenarioOutcome};
 
@@ -339,13 +339,13 @@ mod test {
                 PhaseResult {
                     phase: Phase::Build,
                     duration: Duration::from_secs(2),
-                    process_status: ProcessStatus::Success,
+                    process_status: Exit::Success,
                     argv: vec!["cargo".into(), "build".into()],
                 },
                 PhaseResult {
                     phase: Phase::Test,
                     duration: Duration::from_secs(3),
-                    process_status: ProcessStatus::Success,
+                    process_status: Exit::Success,
                     argv: vec!["cargo".into(), "test".into()],
                 },
             ],
@@ -355,7 +355,7 @@ mod test {
             Some(&PhaseResult {
                 phase: Phase::Build,
                 duration: Duration::from_secs(2),
-                process_status: ProcessStatus::Success,
+                process_status: Exit::Success,
                 argv: vec!["cargo".into(), "build".into()],
             })
         );

--- a/src/process.rs
+++ b/src/process.rs
@@ -171,18 +171,20 @@ impl Exit {
 ///
 /// This is not completely guaranteed, but is only for debug logs.
 fn cheap_shell_quote<S: AsRef<str>, I: IntoIterator<Item = S>>(argv: I) -> String {
-    argv.into_iter()
-        .map(|s| {
-            s.as_ref()
-                .chars()
-                .flat_map(|c| match c {
-                    ' ' | '\t' | '\n' | '\r' | '\\' | '\'' | '"' => vec!['\\', c],
-                    _ => vec![c],
-                })
-                .collect::<String>()
-        })
-        .collect::<Vec<_>>()
-        .join(" ")
+    let mut r = String::new();
+    for s in argv {
+        if !r.is_empty() {
+            r.push(' ');
+        }
+        for c in s.as_ref().chars() {
+            match c {
+                ' ' | '\t' | '\n' | '\r' | '\\' | '\'' | '"' => r.push('\\'),
+                _ => (),
+            }
+            r.push(c);
+        }
+    }
+    r
 }
 
 #[cfg(test)]

--- a/src/process.rs
+++ b/src/process.rs
@@ -159,6 +159,7 @@ pub enum ProcessStatus {
     /// Exceeded its timeout, and killed.
     Timeout,
     /// Killed by some signal.
+    #[cfg(unix)]
     Signalled(u8),
     /// Unknown or unexpected situation.
     Other,

--- a/src/process.rs
+++ b/src/process.rs
@@ -28,12 +28,12 @@ const WAIT_POLL_INTERVAL: Duration = Duration::from_millis(50);
 #[cfg(windows)]
 mod windows;
 #[cfg(windows)]
-use windows::{configure_command, interpret_exit, terminate_child};
+use windows::{configure_command, terminate_child};
 
 #[cfg(unix)]
 mod unix;
 #[cfg(unix)]
-use unix::{configure_command, interpret_exit, terminate_child};
+use unix::{configure_command, terminate_child};
 
 pub struct Process {
     child: Child,
@@ -112,7 +112,7 @@ impl Process {
             self.terminate()?;
             Err(e)
         } else if let Some(status) = self.child.try_wait()? {
-            Ok(Some(interpret_exit(status)))
+            Ok(Some(status.into()))
         } else {
             Ok(None)
         }

--- a/src/process/unix.rs
+++ b/src/process/unix.rs
@@ -1,0 +1,31 @@
+use std::os::unix::process::{CommandExt, ExitStatusExt};
+use std::process::Child;
+
+use anyhow::{bail, Context};
+use nix::errno::Errno;
+use nix::sys::signal::{killpg, Signal};
+use nix::unistd::Pid;
+use trace::warn;
+
+use crate::Result;
+
+#[allow(unknown_lints, clippy::needless_pass_by_ref_mut)] // To match Windows
+#[mutants::skip] // hard to exercise the ESRCH edge case
+pub(super) fn terminate_child_impl(child: &mut Child) -> Result<()> {
+    let pid = Pid::from_raw(child.id().try_into().unwrap());
+    match killpg(pid, Signal::SIGTERM) {
+        Ok(()) => Ok(()),
+        Err(Errno::ESRCH) => {
+            Ok(()) // Probably already gone
+        }
+        Err(Errno::EPERM) if cfg!(target_os = "macos") => {
+            Ok(()) // If the process no longer exists then macos can return EPERM (maybe?)
+        }
+        Err(errno) => {
+            // TODO: Maybe strerror?
+            let message = format!("failed to terminate child: error {errno}");
+            warn!("{}", message);
+            bail!(message);
+        }
+    }
+}

--- a/src/process/unix.rs
+++ b/src/process/unix.rs
@@ -37,16 +37,18 @@ pub(super) fn configure_command(command: &mut Command) {
     command.process_group(0);
 }
 
-pub(super) fn interpret_exit(status: ExitStatus) -> Exit {
-    if let Some(code) = status.code() {
-        if code == 0 {
-            Exit::Success
+impl From<ExitStatus> for Exit {
+    fn from(status: ExitStatus) -> Self {
+        if let Some(code) = status.code() {
+            if code == 0 {
+                Exit::Success
+            } else {
+                Exit::Failure(code as u32)
+            }
+        } else if let Some(signal) = status.signal() {
+            return Exit::Signalled(signal as u8);
         } else {
-            Exit::Failure(code as u32)
+            Exit::Other
         }
-    } else if let Some(signal) = status.signal() {
-        return Exit::Signalled(signal as u8);
-    } else {
-        Exit::Other
     }
 }

--- a/src/process/unix.rs
+++ b/src/process/unix.rs
@@ -9,7 +9,7 @@ use tracing::warn;
 
 use crate::Result;
 
-use super::ProcessStatus;
+use super::Exit;
 
 #[allow(unknown_lints, clippy::needless_pass_by_ref_mut)] // To match Windows
 #[mutants::skip] // hard to exercise the ESRCH edge case
@@ -37,16 +37,16 @@ pub(super) fn configure_command(command: &mut Command) {
     command.process_group(0);
 }
 
-pub(super) fn interpret_exit(status: ExitStatus) -> ProcessStatus {
+pub(super) fn interpret_exit(status: ExitStatus) -> Exit {
     if let Some(code) = status.code() {
         if code == 0 {
-            ProcessStatus::Success
+            Exit::Success
         } else {
-            ProcessStatus::Failure(code as u32)
+            Exit::Failure(code as u32)
         }
     } else if let Some(signal) = status.signal() {
-        return ProcessStatus::Signalled(signal as u8);
+        return Exit::Signalled(signal as u8);
     } else {
-        ProcessStatus::Other
+        Exit::Other
     }
 }

--- a/src/process/windows.rs
+++ b/src/process/windows.rs
@@ -1,8 +1,10 @@
-use std::process::Child;
+use std::process::{Child, Command, ExitStatus};
 
 use anyhow::Context;
 
 use crate::Result;
+
+use super::ProcessStatus;
 
 #[mutants::skip] // hard to exercise the ESRCH edge case
 pub(super) fn terminate_child(child: &mut Child) -> Result<()> {

--- a/src/process/windows.rs
+++ b/src/process/windows.rs
@@ -14,14 +14,16 @@ pub(super) fn terminate_child(child: &mut Child) -> Result<()> {
 #[mutants::skip]
 pub(super) fn configure_command(_command: &mut Command) {}
 
-pub(super) fn interpret_exit(status: ExitStatus) -> Exit {
-    if let Some(code) = status.code() {
-        if code == 0 {
-            Exit::Success
+impl From<ExitStatus> for Exit {
+    fn from(status: ExitStatus) -> Self {
+        if let Some(code) = status.code() {
+            if code == 0 {
+                Exit::Success
+            } else {
+                Exit::Failure(code as u32)
+            }
         } else {
-            Exit::Failure(code as u32)
+            Exit::Other
         }
-    } else {
-        Exit::Other
     }
 }

--- a/src/process/windows.rs
+++ b/src/process/windows.rs
@@ -5,6 +5,21 @@ use anyhow::Context;
 use crate::Result;
 
 #[mutants::skip] // hard to exercise the ESRCH edge case
-pub(super) fn terminate_child_impl(child: &mut Child) -> Result<()> {
+pub(super) fn terminate_child(child: &mut Child) -> Result<()> {
     child.kill().context("Kill child")
+}
+
+#[mutants::skip]
+pub(super) fn configure_command(command: &mut Command) {}
+
+pub(super) fn interpret_exit(status: ExitStatus) -> ProcessStatus {
+    if let Some(code) = status.code() {
+        if code == 0 {
+            ProcessStatus::Success
+        } else {
+            ProcessStatus::Failure(code as u32)
+        }
+    } else {
+        ProcessStatus::Other
+    }
 }

--- a/src/process/windows.rs
+++ b/src/process/windows.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 
 use crate::Result;
 
-use super::ProcessStatus;
+use super::Exit;
 
 #[mutants::skip] // hard to exercise the ESRCH edge case
 pub(super) fn terminate_child(child: &mut Child) -> Result<()> {
@@ -12,16 +12,16 @@ pub(super) fn terminate_child(child: &mut Child) -> Result<()> {
 }
 
 #[mutants::skip]
-pub(super) fn configure_command(command: &mut Command) {}
+pub(super) fn configure_command(_command: &mut Command) {}
 
-pub(super) fn interpret_exit(status: ExitStatus) -> ProcessStatus {
+pub(super) fn interpret_exit(status: ExitStatus) -> Exit {
     if let Some(code) = status.code() {
         if code == 0 {
-            ProcessStatus::Success
+            Exit::Success
         } else {
-            ProcessStatus::Failure(code as u32)
+            Exit::Failure(code as u32)
         }
     } else {
-        ProcessStatus::Other
+        Exit::Other
     }
 }

--- a/src/process/windows.rs
+++ b/src/process/windows.rs
@@ -1,0 +1,10 @@
+use std::process::Child;
+
+use anyhow::Context;
+
+use crate::Result;
+
+#[mutants::skip] // hard to exercise the ESRCH edge case
+pub(super) fn terminate_child_impl(child: &mut Child) -> Result<()> {
+    child.kill().context("Kill child")
+}

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -6,8 +6,6 @@ use std::collections::HashSet;
 use std::env;
 use std::fs::{self, create_dir, read_dir, read_to_string};
 use std::path::Path;
-use std::thread::sleep;
-use std::time::Duration;
 
 use indoc::indoc;
 use itertools::Itertools;
@@ -18,7 +16,7 @@ use pretty_assertions::assert_eq;
 use tempfile::TempDir;
 
 mod util;
-use util::{copy_of_testdata, copy_testdata_to, run, MAIN_BINARY, OUTER_TIMEOUT};
+use util::{copy_of_testdata, copy_testdata_to, run, OUTER_TIMEOUT};
 
 #[test]
 fn incorrect_cargo_subcommand() {
@@ -655,90 +653,6 @@ fn timeout_when_unmutated_tree_test_hangs() {
         .stderr(contains(
             "cargo test failed in an unmutated tree, so no mutants were tested",
         ));
-}
-
-/// If the test hangs and the user (in this case the test suite) interrupts it, then
-/// the `cargo test` child should be killed.
-///
-/// This is a bit hard to directly observe: the property that we really most care
-/// about is that _all_ grandchild processes are also killed and nothing is left
-/// behind. (On Unix, this is accomplished by use of a pgroup.) However that's a bit
-/// hard to mechanically check without reading and interpreting the process tree, which
-/// seems likely to be a bit annoying to do portably and without flakes.
-/// (But maybe we still should?)
-///
-/// An easier thing to test is that the cargo-mutants process _thinks_ it has killed
-/// the children, and we can observe this in the debug log.
-///
-/// In this test cargo-mutants has a very long timeout, but the test driver has a
-/// short timeout, so it should kill cargo-mutants.
-#[test]
-#[cfg(unix)] // Should in principle work on Windows, but does not at the moment.
-fn interrupt_caught_and_kills_children() {
-    // Test a tree that has enough tests that we'll probably kill it before it completes.
-
-    use std::process::{Command, Stdio};
-
-    use nix::libc::pid_t;
-    use nix::sys::signal::{kill, SIGTERM};
-    use nix::unistd::Pid;
-
-    let tmp_src_dir = copy_of_testdata("well_tested");
-    // We can't use `assert_cmd` `timeout` here because that sends the child a `SIGKILL`,
-    // which doesn't give it a chance to clean up. And, `std::process::Command` only
-    // has an abrupt kill.
-
-    // Drop RUST_BACKTRACE because the traceback mentions "panic" handler functions
-    // and we want to check that the process does not panic.
-
-    // Skip baseline because firstly it should already pass but more importantly
-    // #333 exhibited only during non-baseline scenarios.
-    let args = [
-        MAIN_BINARY.to_str().unwrap(),
-        "mutants",
-        "--timeout=300",
-        "--baseline=skip",
-        "--level=trace",
-    ];
-
-    println!("Running: {args:?}");
-    let mut child = Command::new(args[0])
-        .args(&args[1..])
-        .current_dir(&tmp_src_dir)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .env_remove("RUST_BACKTRACE")
-        .spawn()
-        .expect("spawn child");
-
-    sleep(Duration::from_secs(2)); // Let it get started
-    assert!(
-        child.try_wait().expect("try to wait for child").is_none(),
-        "child exited early"
-    );
-
-    println!("Sending SIGTERM to cargo-mutants...");
-    kill(Pid::from_raw(child.id() as pid_t), SIGTERM).expect("send SIGTERM");
-
-    println!("Wait for cargo-mutants to exit...");
-    let output = child
-        .wait_with_output()
-        .expect("wait for child after SIGTERM");
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    println!("stdout:\n{stdout}");
-    println!("stderr:\n{stderr}");
-
-    assert!(stderr.contains("interrupted"));
-    // We used to look here for some other trace messages about how it's interrupted, but
-    // that seems to be racy: sometimes the parent sees the child interrupted before it
-    // emits these messages? Anyhow, it's not essential.
-
-    // This shouldn't cause a panic though (#333)
-    assert!(!stderr.contains("panic"));
-    // And we don't want duplicate messages about workers failing.
-    assert!(!stderr.contains("Worker thread failed"));
 }
 
 /// A tree that hangs when some functions are mutated does not hang cargo-mutants

--- a/tests/unix.rs
+++ b/tests/unix.rs
@@ -1,0 +1,91 @@
+#![cfg(unix)]
+
+use std::thread::sleep;
+use std::time::Duration;
+
+mod util;
+use util::{copy_of_testdata, MAIN_BINARY};
+
+/// If the test hangs and the user (in this case the test suite) interrupts it, then
+/// the `cargo test` child should be killed.
+///
+/// This is a bit hard to directly observe: the property that we really most care
+/// about is that _all_ grandchild processes are also killed and nothing is left
+/// behind. (On Unix, this is accomplished by use of a pgroup.) However that's a bit
+/// hard to mechanically check without reading and interpreting the process tree, which
+/// seems likely to be a bit annoying to do portably and without flakes.
+/// (But maybe we still should?)
+///
+/// An easier thing to test is that the cargo-mutants process _thinks_ it has killed
+/// the children, and we can observe this in the debug log.
+///
+/// In this test cargo-mutants has a very long timeout, but the test driver has a
+/// short timeout, so it should kill cargo-mutants.
+// TODO: An equivalent test on Windows?
+#[test]
+fn interrupt_caught_and_kills_children() {
+    // Test a tree that has enough tests that we'll probably kill it before it completes.
+
+    use std::process::{Command, Stdio};
+
+    use nix::libc::pid_t;
+    use nix::sys::signal::{kill, SIGTERM};
+    use nix::unistd::Pid;
+
+    let tmp_src_dir = copy_of_testdata("well_tested");
+    // We can't use `assert_cmd` `timeout` here because that sends the child a `SIGKILL`,
+    // which doesn't give it a chance to clean up. And, `std::process::Command` only
+    // has an abrupt kill.
+
+    // Drop RUST_BACKTRACE because the traceback mentions "panic" handler functions
+    // and we want to check that the process does not panic.
+
+    // Skip baseline because firstly it should already pass but more importantly
+    // #333 exhibited only during non-baseline scenarios.
+    let args = [
+        MAIN_BINARY.to_str().unwrap(),
+        "mutants",
+        "--timeout=300",
+        "--baseline=skip",
+        "--level=trace",
+    ];
+
+    println!("Running: {args:?}");
+    let mut child = Command::new(args[0])
+        .args(&args[1..])
+        .current_dir(&tmp_src_dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .env_remove("RUST_BACKTRACE")
+        .spawn()
+        .expect("spawn child");
+
+    sleep(Duration::from_secs(2)); // Let it get started
+    assert!(
+        child.try_wait().expect("try to wait for child").is_none(),
+        "child exited early"
+    );
+
+    println!("Sending SIGTERM to cargo-mutants...");
+    kill(Pid::from_raw(child.id() as pid_t), SIGTERM).expect("send SIGTERM");
+
+    println!("Wait for cargo-mutants to exit...");
+    let output = child
+        .wait_with_output()
+        .expect("wait for child after SIGTERM");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    println!("stdout:\n{stdout}");
+    println!("stderr:\n{stderr}");
+
+    assert!(stderr.contains("interrupted"));
+    // We used to look here for some other trace messages about how it's interrupted, but
+    // that seems to be racy: sometimes the parent sees the child interrupted before it
+    // emits these messages? Anyhow, it's not essential.
+
+    // This shouldn't cause a panic though (#333)
+    assert!(!stderr.contains("panic"));
+    // And we don't want duplicate messages about workers failing.
+    assert!(!stderr.contains("Worker thread failed"));
+}


### PR DESCRIPTION
Fixes some warnings on Windows