### PR TITLE
feat: add output directory config via environment variable and config file

### DIFF
--- a/book/src/mutants-out.md
+++ b/book/src/mutants-out.md
@@ -1,6 +1,7 @@
 # The `mutants.out` directory
 
-A `mutants.out` directory is created in the original source directory. You can put the output directory elsewhere with the `--output` option.
+A `mutants.out` directory is created in the original source directory. You can put the output directory elsewhere with the `--output` option
+or using `CARGO_MUTANTS_OUTPUT` environment variable or via `output` directive in the config file.
 
 On each run, any existing `mutants.out` is renamed to `mutants.out.old`, and any
 existing `mutants.out.old` is deleted.

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 use std::str::FromStr;
 
 use anyhow::Context;
-use camino::Utf8Path;
+use camino::{Utf8Path, Utf8PathBuf};
 use serde::Deserialize;
 
 use crate::options::TestTool;
@@ -45,6 +45,8 @@ pub struct Config {
     pub additional_cargo_test_args: Vec<String>,
     /// Minimum test timeout, in seconds, as a floor on the autoset value.
     pub minimum_test_timeout: Option<f64>,
+    /// Output directory.
+    pub output: Option<Utf8PathBuf>,
     /// Cargo profile.
     pub profile: Option<String>,
     /// Skip calls to functions or methods with these names.

--- a/src/main.rs
+++ b/src/main.rs
@@ -274,7 +274,12 @@ pub struct Args {
     line_col: bool,
 
     /// Create mutants.out within this directory.
-    #[arg(long, short = 'o', help_heading = "Output")]
+    #[arg(
+        long,
+        short = 'o',
+        env = "CARGO_MUTANTS_OUTPUT",
+        help_heading = "Output"
+    )]
     output: Option<Utf8PathBuf>,
 
     /// Include only mutants in code touched by this diff.

--- a/src/options.rs
+++ b/src/options.rs
@@ -302,7 +302,7 @@ impl Options {
             jobserver_tasks: args.jobserver_tasks,
             leak_dirs: args.leak_dirs,
             minimum_test_timeout,
-            output_in_dir: args.output.clone(),
+            output_in_dir: args.output.clone().or(config.output.clone()),
             print_caught: args.caught,
             print_unviable: args.unviable,
             profile: args.profile.as_ref().or(config.profile.as_ref()).cloned(),

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -273,7 +273,7 @@ fn output_option_use_config() {
     let testdata = copy_of_testdata("factorial");
     write_config_file(
         &testdata,
-        &format!("output = \"{}\"\n", output_via_config.to_str().unwrap()),
+        &format!("output = \"{}\"\n", output_via_config.display()),
     );
 
     assert!(

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -263,3 +263,50 @@ fn additional_cargo_test_args() {
         .assert()
         .success();
 }
+
+#[test]
+/// Set the `--output` directory via `output` config directive.
+fn output_option_use_config() {
+    let output_tmpdir = TempDir::new().unwrap();
+    let output_via_config = output_tmpdir.path().join("output_via_config");
+
+    let testdata = copy_of_testdata("factorial");
+    write_config_file(
+        &testdata,
+        &format!("output = \"{}\"\n", output_via_config.to_str().unwrap()),
+    );
+
+    assert!(
+        !testdata.path().join("mutants.out").exists(),
+        "mutants.out should not be in a clean copy of the test data"
+    );
+
+    run()
+        .arg("mutants")
+        .args(["--check", "--no-times"])
+        .arg("-d")
+        .arg(testdata.path())
+        .assert()
+        .success();
+
+    assert!(
+        !testdata.path().join("mutants.out").exists(),
+        "mutants.out should not be in the source directory"
+    );
+    let mutants_out = output_via_config.join("mutants.out");
+    assert!(
+        mutants_out.exists(),
+        "mutants.out is in changed `output` directory"
+    );
+    for name in [
+        "mutants.json",
+        "debug.log",
+        "outcomes.json",
+        "missed.txt",
+        "caught.txt",
+        "timeout.txt",
+        "unviable.txt",
+    ] {
+        assert!(mutants_out.join(name).is_file(), "{name} is in mutants.out",);
+    }
+}

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -269,12 +269,13 @@ fn additional_cargo_test_args() {
 fn output_option_use_config() {
     let output_tmpdir = TempDir::new().unwrap();
     let output_via_config = output_tmpdir.path().join("output_via_config");
-
     let testdata = copy_of_testdata("factorial");
-    write_config_file(
-        &testdata,
-        &format!("output = \"{}\"\n", output_via_config.display()),
-    );
+
+    let out_path_str = output_via_config
+        .to_string_lossy()
+        .escape_default()
+        .to_string();
+    write_config_file(&testdata, &format!("output = \"{out_path_str}\""));
 
     assert!(
         !testdata.path().join("mutants.out").exists(),


### PR DESCRIPTION
This PR adds possibility to configure output directory using:
1. `output` key in the config file.
2. `CARGO_MUTANTS_OUTPUT` environment varible.
