### PR TITLE
Specify version-qualified package names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ mutants.out.old
 wiki
 .vscode/
 book/book
+*.snap.new

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_matches"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,6 +170,7 @@ version = "24.11.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "assert_matches",
  "camino",
  "cargo_metadata",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ nix = { version = "0.29", features = ["process", "signal"] }
 
 [dev-dependencies]
 assert_cmd = "2.0"
+assert_matches = "1.5"
 cp_r = { version = "0.5.2" } # git = "https://github.com/sourcefrog/cp_r"
 insta = "1.12"
 lazy_static = "1.4"

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -88,7 +88,7 @@ It is rare but legal in Cargo to have multiple packages with the same base name 
 
 In that case, `cargo build -p itertools` will fail because the name is ambiguous: even though there is only one package of that name in the working tree, the `cargo -p` option can also match against dependencies.
 
-To avoid these problems we invoke cargo with the ["package id"](https://doc.rust-lang.org/cargo/reference/pkgid-spec.html) which should be unambiguous. The package id has a form like `path+file:///tmp/xyz#packagename` and so needs to be synthetisized including the path of the build directory.
+To avoid these problems we invoke cargo with the ["package id"](https://doc.rust-lang.org/cargo/reference/pkgid-spec.html) including the version, which should be ambiguous?
 
 ### Package targets
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 - New: Add `.jj` to the list of known VCS directories. These are excluded by default when copying the tree, but can be included using `--copy-vcs=true`.
 
+- Fixed: `cargo --package` options now include the version number of the targeted package, like `foo@0.1.2`. This avoids cargo failing with an error that the package name is ambiguous in trees whose dependencies include multiple versions of one of the packages being tested.
+
 ## 24.11.2
 
 - Changed: `.gitignore` (and other git ignore files) are only consulted when copying the tree if it is contained within a directory with a `.git` directory.

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -197,12 +197,10 @@ fn encoded_rustflags(options: &Options) -> Option<String> {
 
 #[cfg(test)]
 mod test {
-    use camino::Utf8PathBuf;
     use clap::Parser;
     use pretty_assertions::assert_eq;
     use rusty_fork::rusty_fork_test;
 
-    use crate::package::Package;
     use crate::Args;
 
     use super::*;
@@ -227,18 +225,17 @@ mod test {
     #[test]
     fn generate_cargo_args_with_additional_cargo_test_args_and_package() {
         let mut options = Options::default();
-        let package = Package {
-            name: "cargo-mutants-testdata-something".to_owned(),
-            relative_dir: Utf8PathBuf::new(),
-            top_sources: vec!["src/lib.rs".into()],
-            version: "0.1.0".to_owned(),
-        };
         options
             .additional_cargo_test_args
             .extend(["--lib", "--no-fail-fast"].iter().map(ToString::to_string));
         assert_eq!(
             cargo_argv(
-                &PackageSelection::Explicit(vec![package]),
+                &PackageSelection::one(
+                    "cargo-mutants-testdata-something",
+                    "0.1.0",
+                    "",
+                    "src/lib.rs"
+                ),
                 Phase::Check,
                 &options
             )[1..],

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -143,7 +143,11 @@ fn cargo_argv(packages: &PackageSelection, phase: Phase, options: &Options) -> V
             cargo_args.push("--workspace".to_string());
         }
         PackageSelection::Explicit(packages) => {
-            cargo_args.extend(packages.iter().map(|p| format!("--package={}", p.name)));
+            cargo_args.extend(
+                packages
+                    .iter()
+                    .map(|p| format!("--package={}", p.version_qualified_name())),
+            );
         }
     }
     let features = &options.features;
@@ -236,6 +240,7 @@ mod test {
             name: "cargo-mutants-testdata-something".to_owned(),
             relative_dir: Utf8PathBuf::new(),
             top_sources: vec!["src/lib.rs".into()],
+            version: "0.1.0".to_owned(),
         };
         options
             .additional_cargo_test_args
@@ -253,7 +258,7 @@ mod test {
                 "check",
                 "--tests",
                 "--verbose",
-                "--package=cargo-mutants-testdata-something",
+                "--package=cargo-mutants-testdata-something@0.1.0",
             ]
         );
     }

--- a/src/cargo.rs
+++ b/src/cargo.rs
@@ -129,15 +129,6 @@ fn cargo_argv(packages: &PackageSelection, phase: Phase, options: &Options) -> V
         }
     }
     cargo_args.push("--verbose".to_string());
-    // TODO: If there's just one package then look up its manifest path in the
-    // workspace and use that instead, because it's less ambiguous when there's
-    // multiple different-version packages with the same name in the workspace.
-    // (A rare case, but it happens in itertools.)
-    // if let Some([package]) = package_names {
-    //     // Use the unambiguous form for this case; it works better when the same
-    //     // package occurs multiple times in the tree with different versions?
-    //     cargo_args.push("--manifest-path".to_owned());
-    //     cargo_args.push(build_dir.join(&package.relative_manifest_path).to_string());
     match packages {
         PackageSelection::All => {
             cargo_args.push("--workspace".to_string());
@@ -245,9 +236,6 @@ mod test {
         options
             .additional_cargo_test_args
             .extend(["--lib", "--no-fail-fast"].iter().map(ToString::to_string));
-        // TODO: It would be a bit better to use `--manifest-path` here, to get
-        // the fix for <https://github.com/sourcefrog/cargo-mutants/issues/117>
-        // but it's temporarily regressed.
         assert_eq!(
             cargo_argv(
                 &PackageSelection::Explicit(vec![package]),

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -7,7 +7,7 @@
 
 use std::cmp::{max, min};
 use std::panic::resume_unwind;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
 use std::{thread, vec};
 
@@ -174,9 +174,9 @@ impl Lab<'_> {
     ///
     /// If it succeeds, return the timeouts to be used for the other scenarios.
     fn run_baseline(&self, build_dir: &BuildDir, mutants: &[Mutant]) -> Result<ScenarioOutcome> {
-        let all_mutated_packages = mutants
+        let all_mutated_packages: Vec<Arc<Package>> = mutants
             .iter()
-            .map(|m| m.source_file.package.clone())
+            .map(|m| Arc::clone(&m.source_file.package))
             .sorted_by_key(|p| p.name.clone())
             .unique()
             .collect_vec();
@@ -331,7 +331,7 @@ pub enum TestsForMutant {
     /// Test only the package that was mutated
     Mutated,
     /// Test specific packages
-    Explicit(Vec<Package>),
+    Explicit(Vec<Arc<Package>>),
 }
 
 impl TestsForMutant {

--- a/src/lab.rs
+++ b/src/lab.rs
@@ -177,7 +177,7 @@ impl Lab<'_> {
     fn run_baseline(&self, build_dir: &BuildDir, mutants: &[Mutant]) -> Result<ScenarioOutcome> {
         let all_mutated_packages = mutants
             .iter()
-            .map(|m| m.source_file.package_name.as_str())
+            .map(|m| m.source_file.package.name.clone())
             .unique()
             .collect_vec();
         self.make_worker(build_dir).run_one_scenario(
@@ -240,7 +240,7 @@ impl Worker<'_> {
             let test_package = match &self.options.test_package {
                 TestPackages::Workspace => PackageSelection::All,
                 TestPackages::Mutated => {
-                    PackageSelection::Explicit(vec![mutant.source_file.package_name.clone()])
+                    PackageSelection::Explicit(vec![mutant.source_file.package.name.clone()])
                 }
                 TestPackages::Named(named) => PackageSelection::Explicit(named.clone()),
             };

--- a/src/list.rs
+++ b/src/list.rs
@@ -61,7 +61,7 @@ pub fn list_files(source_files: &[SourceFile], options: &Options) -> String {
                 .map(|source_file| {
                     json!({
                         "path": source_file.tree_relative_path.to_slash_path(),
-                        "package": source_file.package_name,
+                        "package": source_file.package.name,
                     })
                 })
                 .collect(),

--- a/src/mutate.rs
+++ b/src/mutate.rs
@@ -223,7 +223,7 @@ impl fmt::Debug for Mutant {
             .field("replacement", &self.replacement)
             .field("genre", &self.genre)
             .field("span", &self.span)
-            .field("package_name", &self.source_file.package_name)
+            .field("package_name", &self.source_file.package.name)
             .finish()
     }
 }
@@ -235,7 +235,7 @@ impl Serialize for Mutant {
     {
         // custom serialize to omit inessential info
         let mut ss = serializer.serialize_struct("Mutant", 7)?;
-        ss.serialize_field("package", &self.source_file.package_name)?;
+        ss.serialize_field("package", &self.source_file.package.name)?;
         ss.serialize_field("file", &self.source_file.tree_relative_slashes())?;
         ss.serialize_field("function", &self.function.as_ref().map(Arc::as_ref))?;
         ss.serialize_field("span", &self.span)?;

--- a/src/package.rs
+++ b/src/package.rs
@@ -17,6 +17,9 @@ pub struct Package {
     /// The short name of the package, like "mutants".
     pub name: String,
 
+    /// The version of the package, like `"0.1.0"`.
+    pub version: String,
+
     /// The directory for this package relative to the workspace.
     ///
     /// For a package in the root, this is `""`.
@@ -61,8 +64,13 @@ impl Package {
         Some(Package {
             name,
             top_sources: package_top_sources(workspace_root, package_metadata),
+            version: package_metadata.version.to_string(),
             relative_dir,
         })
+    }
+
+    pub fn version_qualified_name(&self) -> String {
+        format!("{}@{}", self.name, self.version)
     }
 }
 

--- a/src/package.rs
+++ b/src/package.rs
@@ -3,9 +3,10 @@
 //! Discover and represent cargo packages within a workspace.
 
 use camino::Utf8PathBuf;
+use serde::Serialize;
 
 /// A package built and tested as a unit.
-#[derive(Debug, Eq, PartialEq, Hash, Clone)]
+#[derive(Debug, Eq, PartialEq, Hash, Clone, Serialize)]
 pub struct Package {
     /// The short name of the package, like "mutants".
     pub name: String,

--- a/src/package.rs
+++ b/src/package.rs
@@ -2,8 +2,14 @@
 
 //! Discover and represent cargo packages within a workspace.
 
-use camino::Utf8PathBuf;
+use anyhow::{anyhow, Result};
+use camino::{Utf8Path, Utf8PathBuf};
+use cargo_metadata::TargetKind;
+use itertools::Itertools;
 use serde::Serialize;
+use tracing::{debug, debug_span, warn};
+
+use crate::interrupt::check_interrupted;
 
 /// A package built and tested as a unit.
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Serialize)]
@@ -19,6 +25,106 @@ pub struct Package {
     /// The top source files for this package, relative to the workspace root,
     /// like `["src/lib.rs"]`.
     pub top_sources: Vec<Utf8PathBuf>,
+}
+
+/// Read `cargo-metadata` parsed output, and produce our package representation.
+pub fn packages_from_metadata(metadata: &cargo_metadata::Metadata) -> Result<Vec<Package>> {
+    let mut packages = Vec::new();
+    for package_metadata in metadata
+        .workspace_packages()
+        .into_iter()
+        .sorted_by_key(|p| &p.name)
+    {
+        check_interrupted()?;
+        packages.push(Package::from_cargo_metadata(
+            package_metadata,
+            &metadata.workspace_root,
+        )?);
+    }
+    Ok(packages)
+}
+
+impl Package {
+    pub fn from_cargo_metadata(
+        package_metadata: &cargo_metadata::Package,
+        workspace_root: &Utf8Path,
+    ) -> Result<Self> {
+        let name = &from.name;
+        let _span = debug_span!("package", %name).entered();
+        let manifest_path = &package_metadata.manifest_path;
+        debug!(%manifest_path, "walk package");
+        let relative_dir = manifest_path
+                .strip_prefix(workspace_root)
+                .map_err(|_| {
+                    // TODO: Maybe just warn and skip?
+                    anyhow!(
+                        "manifest path {manifest_path:?} for package {name:?} is not within the detected source root path {workspace_root:?}",
+                    )
+                })?
+                .parent()
+                .ok_or_else(|| anyhow!("manifest path {manifest_path:?} for package {name:?} has no parent"))?
+                .to_owned();
+        Ok(Package {
+            name: from.name.clone(),
+            top_sources: package_top_sources(workspace_root, from),
+            relative_dir,
+        })
+    }
+}
+
+/// Find all the files that are named in the `path` of targets in a
+/// Cargo manifest, if the kind of the target is one that we should mutate.
+///
+/// These are the starting points for discovering source files.
+fn package_top_sources(
+    workspace_root: &Utf8Path,
+    package_metadata: &cargo_metadata::Package,
+) -> Vec<Utf8PathBuf> {
+    let mut found = Vec::new();
+    let pkg_dir = package_metadata.manifest_path.parent().unwrap();
+    for target in &package_metadata.targets {
+        if should_mutate_target(target) {
+            if let Ok(relpath) = target
+                .src_path
+                .strip_prefix(workspace_root)
+                .map(ToOwned::to_owned)
+            {
+                debug!(
+                    "found mutation target {} of kind {:?}",
+                    relpath, target.kind
+                );
+                found.push(relpath);
+            } else {
+                warn!("{:?} is not in {:?}", target.src_path, pkg_dir);
+            }
+        } else {
+            debug!(
+                "skipping target {:?} of kinds {:?}",
+                target.name, target.kind
+            );
+        }
+    }
+    found.sort();
+    found.dedup();
+    found
+}
+
+fn should_mutate_target(target: &cargo_metadata::Target) -> bool {
+    for kind in &target.kind {
+        if matches!(
+            kind,
+            TargetKind::Bin
+                | TargetKind::ProcMacro
+                | TargetKind::CDyLib
+                | TargetKind::DyLib
+                | TargetKind::Lib
+                | TargetKind::RLib
+                | TargetKind::StaticLib
+        ) {
+            return true;
+        }
+    }
+    false
 }
 
 /// A more specific view of which packages to mutate, after resolving `PackageFilter::Auto`.

--- a/src/package.rs
+++ b/src/package.rs
@@ -110,8 +110,8 @@ fn package_top_sources(
 }
 
 fn should_mutate_target(target: &cargo_metadata::Target) -> bool {
-    for kind in &target.kind {
-        if matches!(
+    target.kind.iter().any(|kind| {
+        matches!(
             kind,
             TargetKind::Bin
                 | TargetKind::ProcMacro
@@ -120,11 +120,8 @@ fn should_mutate_target(target: &cargo_metadata::Target) -> bool {
                 | TargetKind::Lib
                 | TargetKind::RLib
                 | TargetKind::StaticLib
-        ) {
-            return true;
-        }
-    }
-    false
+        )
+    })
 }
 
 /// A more specific view of which packages to mutate, after resolving `PackageFilter::Auto`.

--- a/src/package.rs
+++ b/src/package.rs
@@ -9,6 +9,9 @@ use serde::Serialize;
 use tracing::{debug, debug_span, warn};
 
 /// A package built and tested as a unit.
+///
+/// This is an internal representation derived from and similar to a `cargo_metadata::Package`,
+/// in a more digested form and as an extension point for later supporting tools other than Cargo.
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Serialize)]
 pub struct Package {
     /// The short name of the package, like "mutants".
@@ -81,8 +84,8 @@ fn package_top_sources(
                 .map(ToOwned::to_owned)
             {
                 debug!(
-                    "found mutation target {} of kind {:?}",
-                    relpath, target.kind
+                    "found mutation target {relpath} of kind {kind:?}",
+                    kind = target.kind
                 );
                 found.push(relpath);
             } else {
@@ -115,18 +118,12 @@ fn should_mutate_target(target: &cargo_metadata::Target) -> bool {
     })
 }
 
-/// A more specific view of which packages to mutate, after resolving `PackageFilter::Auto`.
+/// Selection of which specific packages to mutate or test.
 #[derive(Debug, Clone)]
 #[allow(clippy::module_name_repetitions)]
 pub enum PackageSelection {
+    /// All packages in the workspace.
     All,
-    /// Explicitly selected packages, by qualname.
-    Explicit(Vec<String>),
-}
-
-impl PackageSelection {
-    /// Helper constructor for `PackageSelection::Explicit`.
-    pub fn explicit<I: IntoIterator<Item = S>, S: ToString>(names: I) -> Self {
-        Self::Explicit(names.into_iter().map(|s| s.to_string()).collect())
-    }
+    /// Explicitly selected packages.
+    Explicit(Vec<Package>),
 }

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -1,4 +1,4 @@
-// Copyright 2021-2023 Martin Pool
+// Copyright 2021-2025 Martin Pool
 
 use serde::Serialize;
 use std::fmt;
@@ -6,6 +6,7 @@ use std::fmt;
 use crate::Mutant;
 
 /// A scenario is either a freshening build in the source tree, a baseline test with no mutations, or a mutation test.
+#[allow(clippy::large_enum_variant)] // baselines are uncommon, size doesn't matter much?
 #[derive(Clone, Eq, PartialEq, Debug, Serialize)]
 pub enum Scenario {
     /// Build in a copy of the source tree but with no mutations applied.

--- a/src/scenario.rs
+++ b/src/scenario.rs
@@ -6,7 +6,6 @@ use std::fmt;
 use crate::Mutant;
 
 /// A scenario is either a freshening build in the source tree, a baseline test with no mutations, or a mutation test.
-#[allow(clippy::large_enum_variant)] // baselines are uncommon, size doesn't matter much?
 #[derive(Clone, Eq, PartialEq, Debug, Serialize)]
 pub enum Scenario {
     /// Build in a copy of the source tree but with no mutations applied.

--- a/src/source.rs
+++ b/src/source.rs
@@ -25,7 +25,7 @@ use crate::span::LineColumn;
 #[allow(clippy::module_name_repetitions)]
 pub struct SourceFile {
     /// What package includes this file?
-    pub package: Package,
+    pub package: Arc<Package>,
 
     /// Path of this source file relative to workspace.
     pub tree_relative_path: Utf8PathBuf,
@@ -70,7 +70,7 @@ impl SourceFile {
         Ok(Some(SourceFile {
             tree_relative_path: tree_relative_path.to_owned(),
             code,
-            package: package.clone(),
+            package: Arc::new(package.clone()),
             is_top,
         }))
     }
@@ -92,12 +92,12 @@ impl SourceFile {
         SourceFile {
             tree_relative_path,
             code: Arc::new(code.to_owned()),
-            package: Package {
+            package: Arc::new(Package {
                 name: package_name.to_owned(),
                 relative_dir: Utf8PathBuf::new(),
                 top_sources,
                 version: "0.1.0".to_owned(),
-            },
+            }),
             is_top,
         }
     }
@@ -155,12 +155,12 @@ mod test {
 
     #[test]
     fn skips_files_outside_of_workspace() {
-        let package = Package {
+        let package = Arc::new(Package {
             name: "imaginary-package".to_owned(),
             relative_dir: Utf8PathBuf::from(""),
             top_sources: vec!["src/lib.rs".into()],
             version: "0.1.0".to_owned(),
-        };
+        });
         let source_file = SourceFile::load(
             Utf8Path::new("unimportant"),
             Utf8Path::new("../outside_workspace.rs"),

--- a/src/source.rs
+++ b/src/source.rs
@@ -96,6 +96,7 @@ impl SourceFile {
                 name: package_name.to_owned(),
                 relative_dir: Utf8PathBuf::new(),
                 top_sources,
+                version: "0.1.0".to_owned(),
             },
             is_top,
         }
@@ -144,6 +145,7 @@ mod test {
             name: "imaginary-package".to_owned(),
             relative_dir: Utf8PathBuf::from(""),
             top_sources: vec!["src/lib.rs".into()],
+            version: "0.1.0".to_owned(),
         };
         let source_file = SourceFile::load(temp_dir_path, Utf8Path::new(file_name), &package, true)
             .unwrap()
@@ -157,6 +159,7 @@ mod test {
             name: "imaginary-package".to_owned(),
             relative_dir: Utf8PathBuf::from(""),
             top_sources: vec!["src/lib.rs".into()],
+            version: "0.1.0".to_owned(),
         };
         let source_file = SourceFile::load(
             Utf8Path::new("unimportant"),

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -162,7 +162,7 @@ fn walk_file(
 /// The source code is assumed to be named `src/main.rs` with a fixed package name.
 #[cfg(test)]
 pub fn mutate_source_str(code: &str, options: &Options) -> Result<Vec<Mutant>> {
-    let source_file = SourceFile::from_str(
+    let source_file = SourceFile::for_tests(
         Utf8Path::new("src/main.rs"),
         code,
         "cargo-mutants-testdata-internal",
@@ -855,13 +855,7 @@ mod test {
         let code = indoc! { "
             fn always_true() -> bool { true }
         "};
-        let source_file = SourceFile {
-            code: Arc::new(code.to_owned()),
-            package_name: "unimportant".to_owned(),
-            package_relative_dir: Utf8PathBuf::from(""),
-            tree_relative_path: Utf8PathBuf::from("src/lib.rs"),
-            is_top: true,
-        };
+        let source_file = SourceFile::for_tests("src/lib.rs", code, "unimportant", true);
         let (mutants, _files) =
             walk_file(&source_file, &[], &Options::default()).expect("walk_file");
         let mutant_names = mutants.iter().map(|m| m.name(false)).collect_vec();

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -97,7 +97,7 @@ fn walk_package(
     let mut filename_queue =
         VecDeque::from_iter(package.top_sources.iter().map(|p| (p.to_owned(), true)));
     while let Some((path, package_top)) = filename_queue.pop_front() {
-        let Some(source_file) = SourceFile::load(workspace_dir, &path, &package.name, package_top)?
+        let Some(source_file) = SourceFile::load(workspace_dir, &path, package, package_top)?
         else {
             info!("Skipping source file outside of tree: {path:?}");
             continue;

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -59,7 +59,7 @@ impl Discovered {
 /// they generated mutants or not).
 pub fn walk_tree(
     workspace_dir: &Utf8Path,
-    packages: &[Package],
+    packages: &[Arc<Package>],
     options: &Options,
     console: &Console,
 ) -> Result<Discovered> {

--- a/src/workspace.rs
+++ b/src/workspace.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-2024 Martin Pool
+// Copyright 2023-2025 Martin Pool
 
 //! Understand cargo workspaces, which can contain multiple packages.
 //!
@@ -163,7 +163,7 @@ impl Workspace {
             .exec()
             .with_context(|| format!("Failed to run cargo metadata on {manifest_path}"))?;
         debug!(workspace_root = ?metadata.workspace_root, "Found workspace root");
-        let packages = packages_from_metadata(&metadata)?;
+        let packages = packages_from_metadata(&metadata);
         Ok(Workspace { metadata, packages })
     }
 

--- a/tests/workspace.rs
+++ b/tests/workspace.rs
@@ -1,4 +1,4 @@
-// Copyright 2023-2024 Martin Pool
+// Copyright 2023-2025 Martin Pool
 
 //! Tests for cargo workspaces with multiple packages.
 
@@ -7,6 +7,7 @@ use std::fs::{self, create_dir, read_to_string, write};
 use insta::assert_snapshot;
 use itertools::Itertools;
 use predicates::prelude::predicate;
+use pretty_assertions::assert_eq;
 use serde_json::json;
 
 mod util;
@@ -141,9 +142,9 @@ fn workspace_tree_is_well_tested() {
                 "test",
                 "--no-run",
                 "--verbose",
-                "--package=cargo_mutants_testdata_workspace_utils",
-                "--package=main",
-                "--package=main2"
+                "--package=cargo_mutants_testdata_workspace_utils@0.1.0",
+                "--package=main@0.1.0",
+                "--package=main2@0.1.0"
             ]
         );
         assert_eq!(baseline_phases[1]["process_status"], "Success");
@@ -158,9 +159,9 @@ fn workspace_tree_is_well_tested() {
             [
                 "test",
                 "--verbose",
-                "--package=cargo_mutants_testdata_workspace_utils",
-                "--package=main",
-                "--package=main2"
+                "--package=cargo_mutants_testdata_workspace_utils@0.1.0",
+                "--package=main@0.1.0",
+                "--package=main2@0.1.0"
             ],
         );
     }
@@ -200,9 +201,9 @@ fn workspace_tree_is_well_tested() {
                 "test",
                 "--no-run",
                 "--verbose",
-                "--package=cargo_mutants_testdata_workspace_utils",
-                "--package=main",
-                "--package=main2"
+                "--package=cargo_mutants_testdata_workspace_utils@0.1.0",
+                "--package=main@0.1.0",
+                "--package=main2@0.1.0"
             ],
         );
         assert_eq!(baseline_phases[1]["process_status"], "Success");
@@ -214,9 +215,9 @@ fn workspace_tree_is_well_tested() {
             [
                 "test",
                 "--verbose",
-                "--package=cargo_mutants_testdata_workspace_utils",
-                "--package=main",
-                "--package=main2"
+                "--package=cargo_mutants_testdata_workspace_utils@0.1.0",
+                "--package=main@0.1.0",
+                "--package=main2@0.1.0"
             ],
         );
     }


### PR DESCRIPTION
This should disambiguate in trees that have multiple versions of the package that we want to test.

Fixes #117