### PR TITLE
Don't exclude gitignored files by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 - Changed: Mutate `&T` to `Box::leak(Box::new(...))` so that mutants aren't unviable due to returning references to temporary values.
 
+- **Breaking**: The `--gitignore` option now defaults to `false`, meaning `.gitignore` patterns are no longer respected when copying source trees by default. The `/target` directory is still excluded by default through explicit filtering. To restore the previous behavior, use `--gitignore=true`. This reduces the chance that the build will fail in a copied directory due to missing files, at the risk of potentially copying more files than are strictly necessary.
+
 ## 25.0.1 2025-02-08
 
 - New: Additional mutation patterns: delete `match` arms if there is a default arm, and replace `if` guards from match arms with `true` and `false`.

--- a/book/src/build-dirs.md
+++ b/book/src/build-dirs.md
@@ -26,15 +26,15 @@ If your tree's build or tests require the VCS directory then it can be copied wi
 
 ## `.gitignore`
 
-From 23.11.2, by default, cargo-mutants will not copy files that are excluded by gitignore patterns, to make copying faster in large trees.
+From 25.0.2, by default, cargo-mutants will copy all files except those explicitly excluded (such as `target/`, `mutants.out`, and VCS directories). Previously, gitignore patterns were respected by default.
 
 gitignore filtering is only used within trees containing a `.git` directory.
 
 The filter, based on the [`ignore` crate](https://docs.rs/ignore/), also respects global git ignore configuration in the home directory, as well as `.gitignore` files within the tree.
 
-This behavior can be turned off with `--gitignore=false`, causing ignored files to be copied.
+gitignore filtering can be enabled with `--gitignore=true`, causing files matching gitignore patterns to be excluded from copying.
 
-Rust projects typically configure gitignore to exclude the `target/` directory.
+The `target/` directory is excluded by default, regardless of gitignore settings, to avoid copying large build artifacts that are typically not needed for mutation testing.
 
 ## `mutants.out`
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -201,7 +201,7 @@ pub struct Args {
     file: Vec<String>,
 
     /// Don't copy files matching gitignore patterns.
-    #[arg(long, action = ArgAction::Set, default_value = "true", help_heading = "Copying", group = "copy_opts")]
+    #[arg(long, action = ArgAction::Set, default_value = "false", help_heading = "Copying", group = "copy_opts")]
     gitignore: bool,
 
     /// Test mutations in the source tree, rather than in a copy.

--- a/tests/build_dir.rs
+++ b/tests/build_dir.rs
@@ -6,16 +6,16 @@ mod util;
 use util::{copy_of_testdata, run};
 
 #[test]
-fn gitignore_respected_in_copy_by_default() {
+fn gitignore_respected_when_enabled() {
     // Make a tree with a (dumb) gitignore that excludes the source file; when you copy it
-    // to a build directory, the source file should not be there and so the check will fail.
+    // to a build directory with gitignore enabled, the source file should not be there and so the check will fail.
     let tmp = copy_of_testdata("factorial");
     // There must be something that looks like a `.git` dir, otherwise we don't read
     // `.gitignore` files.
     create_dir(tmp.path().join(".git")).unwrap();
     write(tmp.path().join(".gitignore"), b"src\n").unwrap();
     run()
-        .args(["mutants", "--check", "-d"])
+        .args(["mutants", "--check", "--gitignore=true", "-d"])
         .arg(tmp.path())
         .assert()
         .stdout(predicates::str::contains("can't find `factorial` bin"))
@@ -30,6 +30,22 @@ fn gitignore_can_be_turned_off() {
     write(tmp.path().join(".gitignore"), b"src\n").unwrap();
     run()
         .args(["mutants", "--check", "--gitignore=false", "-d"])
+        .arg(tmp.path())
+        .assert()
+        .success();
+}
+
+#[test]
+fn gitignore_not_respected_by_default() {
+    // Make a tree with a (dumb) gitignore that excludes the source file; when you copy it
+    // to a build directory by default (gitignore=false), it should succeed because gitignore is ignored.
+    let tmp = copy_of_testdata("factorial");
+    // There must be something that looks like a `.git` dir, otherwise we don't read
+    // `.gitignore` files anyway.
+    create_dir(tmp.path().join(".git")).unwrap();
+    write(tmp.path().join(".gitignore"), b"src\n").unwrap();
+    run()
+        .args(["mutants", "--check", "-d"])
         .arg(tmp.path())
         .assert()
         .success();


### PR DESCRIPTION
This sometimes breaks the build and probably only saves a little bit of time.

Fixes #454