### PR TITLE
Mutate NonZero<T> generic return types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-mutants"
-version = "27.0.0"
+version = "27.1.0-pre"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-mutants"
-version = "27.0.0"
+version = "27.1.0-pre"
 edition = "2024"
 authors = ["Martin Pool"]
 license = "MIT"

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # cargo-mutants changelog
 
+## Unreleased
+
+- New: mutate `NonZero<T>` into `1`, and also `-1` when `T` is or may be signed.
+
 ## 27.0.0
 
 Released 2026-03-07.

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -25,7 +25,7 @@
   - [Testing in-place](in-place.md)
   - [Iterating on missed mutants](iterate.md)
   - [Strict lints](lints.md)
-- [Generating mutants](mutants.md)
+- [Mutation patterns](mutants.md)
   - [Error values](error-values.md)
   - [Macros](macros.md)
 - [Improving performance](performance.md)

--- a/book/src/mutants.md
+++ b/book/src/mutants.md
@@ -1,4 +1,4 @@
-# Generating mutants
+# Mutation patterns
 
 cargo mutants generates mutants by inspecting the existing
 source code and applying a set of rules to generate new code
@@ -36,6 +36,7 @@ More mutation genres and patterns will be added in future releases.
 | floats            | `0.0, 1.0, -1.0`                                           |
 | `NonZeroI*`       | `1.try_into().unwrap(), (-1).try_into().unwrap()`            |
 | `NonZeroU*`       | `1.try_into().unwrap()`                                    |
+| `NonZero<T>`      | `1.try_into().unwrap(), (-1).try_into().unwrap()`: negative values are omitted if `T` seems to be unsigned |
 | `bool`            | `true`, `false` |
 | `String`          | `String::new()`, `"xyzzy".into()` |
 | `&'_ str` .       | `""`, `"xyzzy"` |

--- a/src/fnvalue.rs
+++ b/src/fnvalue.rs
@@ -56,6 +56,22 @@ fn type_replacements(type_: &Type, error_exprs: &[Expr]) -> impl Iterator<Item =
                 ]
             } else if path_is_nonzero_unsigned(path) {
                 vec![quote! { 1.try_into().unwrap() }]
+            } else if let Some(inner_type) = match_first_type_arg(path, "NonZero") {
+                // NonZero<T> generic form (stabilized in Rust 1.79)
+                if let Type::Path(syn::TypePath {
+                    path: inner_path, ..
+                }) = inner_type
+                    && path_is_unsigned(inner_path)
+                {
+                    // NonZero<T> where T is an unsigned type can only be positive.
+                    vec![quote! { 1.try_into().unwrap() }]
+                } else {
+                    // NonZero<T> where T is a signed type or an unknown type could be positive or negative.
+                    vec![
+                        quote! { 1.try_into().unwrap() },
+                        quote! { (-1).try_into().unwrap() },
+                    ]
+                }
             } else if path_is_float(path) {
                 vec![quote! { 0.0 }, quote! { 1.0 }, quote! { -1.0 }]
             } else if path_ends_with(path, "Result") {
@@ -393,7 +409,6 @@ fn path_is_nonzero_signed(path: &Path) -> bool {
 }
 
 fn path_is_nonzero_unsigned(path: &Path) -> bool {
-    // TODO: Also NonZero<usize> etc.
     if let Some(l) = path.segments.last().map(|p| p.ident.to_string()) {
         matches!(
             l.as_str(),
@@ -491,6 +506,58 @@ mod test {
             &parse_quote! { -> std::num::NonZeroU32 },
             &[],
             &["1.try_into().unwrap()"],
+        );
+    }
+
+    #[test]
+    fn nonzero_generic_unsigned_replacements() {
+        check_replacements(
+            &parse_quote! { -> NonZero<u32> },
+            &[],
+            &["1.try_into().unwrap()"],
+        );
+
+        check_replacements(
+            &parse_quote! { -> NonZero<usize> },
+            &[],
+            &["1.try_into().unwrap()"],
+        );
+
+        check_replacements(
+            &parse_quote! { -> std::num::NonZero<u8> },
+            &[],
+            &["1.try_into().unwrap()"],
+        );
+    }
+
+    #[test]
+    fn nonzero_generic_signed_replacements() {
+        check_replacements(
+            &parse_quote! { -> NonZero<i32> },
+            &[],
+            &["1.try_into().unwrap()", "(-1).try_into().unwrap()"],
+        );
+
+        check_replacements(
+            &parse_quote! { -> NonZero<isize> },
+            &[],
+            &["1.try_into().unwrap()", "(-1).try_into().unwrap()"],
+        );
+
+        check_replacements(
+            &parse_quote! { -> std::num::NonZero<i64> },
+            &[],
+            &["1.try_into().unwrap()", "(-1).try_into().unwrap()"],
+        );
+    }
+
+    #[test]
+    fn nonzero_generic_unknown_type_replacements() {
+        // When T is not a recognized integer type, assume it could be signed.
+        check_replacements(
+            &parse_quote! { -> NonZero<T> },
+            &[],
+            &["1.try_into().unwrap()", "(-1).try_into().unwrap()"],
         );
     }
 


### PR DESCRIPTION
## Summary
- Support the generic `NonZero<T>` form (stabilized in Rust 1.79) in addition to the existing `NonZeroUsize`, `NonZeroI32`, etc. type-specific matching
- When `T` is a known unsigned type, generate `1`; when signed, generate `1` and `-1`; when `T` is unknown, assume it could be signed and generate both
- Adds tests for unsigned, signed, and unknown type parameter cases

Closes #595

## Test plan
- [x] Unit tests for `NonZero<u32>`, `NonZero<usize>`, `std::num::NonZero<u8>` (unsigned)
- [x] Unit tests for `NonZero<i32>`, `NonZero<isize>`, `std::num::NonZero<i64>` (signed)
- [x] Unit test for `NonZero<T>` with unknown type parameter
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)