### PR TITLE
Fix pre-existing clippy warnings

### DIFF
--- a/src/glob.rs
+++ b/src/glob.rs
@@ -177,7 +177,7 @@ mod test {
     #[test]
     #[cfg(windows)]
     fn on_windows_backslash_is_path_separator() {
-        let set = build_glob_set(&["src\\*.rs"])
+        let set = build_glob_set(["src\\*.rs"])
             .expect("build GlobSet")
             .expect("GlobSet should not be empty");
         assert!(set.is_match("src\\foo.rs"));

--- a/tests/integration_util/mod.rs
+++ b/tests/integration_util/mod.rs
@@ -37,6 +37,12 @@ pub fn run() -> assert_cmd::Command {
 }
 
 /// Returns the path to the cargo-mutants binary under test.
+///
+/// Currently only consumed by Unix-only tests (e.g., signal-handling tests
+/// that need to spawn the binary directly via `std::process::Command`), so
+/// the function is gated on `cfg(unix)` to avoid a `dead_code` warning on
+/// other platforms.
+#[cfg(unix)]
 pub fn main_binary() -> &'static std::path::Path {
     assert_cmd::cargo_bin!("cargo-mutants")
 }


### PR DESCRIPTION
Two long-standing clippy errors trip `cargo clippy --all-targets --all-features -- -D warnings`:

1. `src/glob.rs:180` — `needless_borrows_for_generic_args`: the Windows-only test passed `&["src\\*.rs"]` to `build_glob_set`, which takes `I: IntoIterator<Item = S>`. Every other call site in the same file passes the array directly (e.g. `["foo.rs"]`); drop the redundant `&` to match.

2. `tests/integration_util/mod.rs:40` — `dead_code`: `main_binary` is only consumed by the `#[cfg(unix)]` `interrupt_caught_and_kills_children` test in `tests/main.rs`, so it appears dead on non-Unix targets. Gate the function on `cfg(unix)` to match its sole consumer and add a doc comment explaining why.