### PR TITLE
Add supports of TOML 1.1 that cames with rust 1.94.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -460,7 +460,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -562,9 +562,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -615,12 +615,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1110,7 +1110,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1123,7 +1123,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1250,11 +1250,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1369,7 +1369,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1452,37 +1452,42 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c226a7bba6d859b63c92c4b4fe69c5b6b72d0cb897dbc8e6012298e6154cb56e"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "serde",
+ "indexmap 2.14.0",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
-name = "toml_edit"
-version = "0.20.7"
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "indexmap 2.7.1",
- "serde",
- "serde_spanned",
- "toml_datetime",
  "winnow",
 ]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -1724,7 +1729,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1817,12 +1822,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ similar = "2.1"
 strum = { version = "0.26", features = ["derive"] }
 tempfile = "3.20"
 test-log = { version = "0.2.16", features = ["trace"] }
-toml = "0.8"
+toml = "1.1.2"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.20"
 whoami = "1.5"

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -39,33 +39,33 @@ pub fn fix_manifest(manifest_scratch_path: &Utf8Path, source_dir: &Utf8Path) -> 
 fn fix_manifest_toml(
     manifest_toml: &str,
     manifest_source_dir: &Utf8Path,
-) -> Result<Option<toml::Value>> {
-    let mut value: toml::Value = manifest_toml.parse().context("parse manifest")?;
-    let orig_value = value.clone();
-    if let Some(top_table) = value.as_table_mut() {
-        if let Some(dependencies) = top_table.get_mut("dependencies") {
+) -> Result<Option<toml::Table>> {
+    let mut top_table = manifest_toml
+        .parse::<toml::Table>()
+        .context("parse manifest")?;
+    let original_top_table = top_table.clone();
+    if let Some(dependencies) = top_table.get_mut("dependencies") {
+        fix_dependency_table(dependencies, manifest_source_dir);
+    }
+    if let Some(replace) = top_table.get_mut("replace") {
+        // The replace section is a table from package name/version to a
+        // table which might include a `path` key. (The keys are not exactly
+        // package names but it doesn't matter.)
+        // <https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-replace-section>
+        fix_dependency_table(replace, manifest_source_dir);
+    }
+    if let Some(patch_table) = top_table.get_mut("patch").and_then(|p| p.as_table_mut()) {
+        // The keys of the patch table are registry names or source URLs;
+        // the values are like dependency tables.
+        // <https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section>
+        for (_name, dependencies) in patch_table {
             fix_dependency_table(dependencies, manifest_source_dir);
         }
-        if let Some(replace) = top_table.get_mut("replace") {
-            // The replace section is a table from package name/version to a
-            // table which might include a `path` key. (The keys are not exactly
-            // package names but it doesn't matter.)
-            // <https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-replace-section>
-            fix_dependency_table(replace, manifest_source_dir);
-        }
-        if let Some(patch_table) = top_table.get_mut("patch").and_then(|p| p.as_table_mut()) {
-            // The keys of the patch table are registry names or source URLs;
-            // the values are like dependency tables.
-            // <https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section>
-            for (_name, dependencies) in patch_table {
-                fix_dependency_table(dependencies, manifest_source_dir);
-            }
-        }
     }
-    if value == orig_value {
+    if top_table == original_top_table {
         Ok(None)
     } else {
-        Ok(Some(value))
+        Ok(Some(top_table))
     }
 }
 
@@ -119,9 +119,11 @@ pub fn fix_cargo_config(build_path: &Utf8Path, source_path: &Utf8Path) -> Result
 ///
 /// See <https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html?search=#paths-overrides>.
 fn fix_cargo_config_toml(config_toml: &str, source_dir: &Utf8Path) -> Result<Option<String>> {
-    let mut value: toml::Value = config_toml.parse().context("parse config.toml")?;
+    let mut top_table = config_toml
+        .parse::<toml::Table>()
+        .context("parse config.toml")?;
     let mut changed = false;
-    if let Some(paths) = value.get_mut("paths").and_then(|p| p.as_array_mut()) {
+    if let Some(paths) = top_table.get_mut("paths").and_then(|p| p.as_array_mut()) {
         for path_value in paths {
             if let Some(path_str) = path_value.as_str()
                 && let Some(new_path) = fix_path(path_str, source_dir)
@@ -132,7 +134,7 @@ fn fix_cargo_config_toml(config_toml: &str, source_dir: &Utf8Path) -> Result<Opt
         }
     }
     if changed {
-        Ok(Some(toml::to_string_pretty(&value)?))
+        Ok(Some(toml::to_string_pretty(&top_table)?))
     } else {
         Ok(None)
     }
@@ -211,6 +213,46 @@ mod test {
         assert_eq!(
             fixed["dependencies"]["wibble"]["path"].as_str().unwrap(),
             Utf8Path::new("/home/user/src/foo/../wibble")
+        );
+    }
+
+    #[test]
+    fn fix_manifest_toml_supports_multiline_inline_table_dependencies() {
+        let manifest_toml = indoc! { r#"
+            [package]
+            name = "demo"
+            version = "0.1.0"
+
+            [dependencies]
+            axum-extra = {
+                version = "0.12.5",
+                features = ["typed-header"],
+                path = "../axum-extra",
+            }
+        "# };
+        let orig_path = Utf8Path::new("/home/user/src/foo");
+        let fixed = fix_manifest_toml(manifest_toml, orig_path)
+            .unwrap()
+            .expect("toml was modified");
+
+        assert_eq!(
+            fixed["dependencies"]["axum-extra"]["version"].as_str(),
+            Some("0.12.5")
+        );
+        assert_eq!(
+            fixed["dependencies"]["axum-extra"]["features"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|value| value.as_str())
+                .collect::<Vec<_>>(),
+            [Some("typed-header")]
+        );
+        assert_eq!(
+            fixed["dependencies"]["axum-extra"]["path"]
+                .as_str()
+                .unwrap(),
+            Utf8Path::new("/home/user/src/foo/../axum-extra")
         );
     }
 


### PR DESCRIPTION
Fixes #619 

* I updated `toml` to `1.1.2` to ensure support of TOML 1.1
* Since `toml` 1.x is now parsing single TOML value and not a whole document when performing value parsing like this: `let mut value: toml::Value = manifest_toml.parse()?` as currently `manifest.rs`, I updated it to parse a table so that we have the whole document map like before, fixing the breaking change.

I validated that all tests are still passing, and that I can now test my mutants with latest rust and cargo versions, which is currently not possible with the upstream latest version of cargo mutants:
```
❯ cargo mutants
Found 536 mutants to test
0/536 mutants tested, 0s elapsedError: parse manifest

Caused by:
    TOML parse error at line 24, column 15
       |
    24 | axum-extra = {
       |               ^
    invalid inline table
    expected `}`


laplace on  HEAD (6ae9edc) [✘!] is 📦 v0.1.0 via 🦀 v1.96.0
❯ ../cargo-mutants/target/debug/cargo-mutants mutants
Found 536 mutants to test
build    Unmutated baseline ... 2s
```

I also added a new test case for this scenario:
```toml
[dependencies]
axum-extra = {
    version = "0.12.5",
    features = ["typed-header"],
    path = "../axum-extra",
}
```

All tests are still passing.

```shell
        PASS [   7.500s] cargo-mutants::main workspace_tree_is_well_tested
        PASS [  15.922s] cargo-mutants::main iterate_retries_missed_mutants
        PASS [  19.923s] cargo-mutants::main insta_test_failures_are_detected
        PASS [  12.191s] cargo-mutants::main tree_with_child_directories_is_well_tested
        PASS [  17.448s] cargo-mutants::main log_file_names_are_short_and_dont_collide
────────────
     Summary [  30.844s] 399 tests run: 399 passed, 2 skipped
```