### PR TITLE
Honor #[mutants::skip] on const and static items

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # cargo-mutants changelog
 
+## Unreleased
+
+- Fixed: `#[mutants::skip]` (and `#[cfg_attr(..., mutants::skip)]`) is now honoured when placed on `const` and `static` items, including associated constants in `impl` and `trait` blocks. Previously the attribute was silently ignored on these items and operator mutants inside the initializer expression were still generated ([#508](https://github.com/sourcefrog/cargo-mutants/issues/508)).
+
 ## 27.1.0
 
 Released 2026-06-02.

--- a/book/src/attrs.md
+++ b/book/src/attrs.md
@@ -59,6 +59,9 @@ mod test {
 - **`trait` blocks** — applies to all default method implementations.
 - **`mod` blocks** — applies to all items within the module.
 - **Files** (as an inner attribute `#![mutants::skip]`) — applies to the entire file.
+- **`const` and `static` items** — applies to mutations generated from
+  inside the initializer expression. This also covers associated constants
+  declared inside `impl` and `trait` blocks.
 - **Expressions** that can syntactically carry an outer attribute, including
   `match`, struct literal (`Foo { ... }`), call (`foo(...)`), method-call
   (`x.foo(...)`), and unary expressions (`!x`, `-x`) — applies to the

--- a/src/visit.rs
+++ b/src/visit.rs
@@ -497,6 +497,77 @@ impl<'ast> Visit<'ast> for DiscoveryVisitor<'_> {
         }
     }
 
+    /// Visit a top-level `const FOO: T = ...;` item.
+    ///
+    /// The visitor itself does not generate const-specific mutants, but it
+    /// honours `#[mutants::skip]` on the item so that operator mutants inside
+    /// the initializer expression can be suppressed.
+    fn visit_item_const(&mut self, i: &'ast syn::ItemConst) {
+        let _span = trace_span!(
+            "const",
+            line = i.const_token.span.start().line,
+            name = i.ident.to_pretty_string()
+        )
+        .entered();
+        if attrs_excluded(&i.attrs) {
+            trace!("const excluded by attrs");
+            return;
+        }
+        syn::visit::visit_item_const(self, i);
+    }
+
+    /// Visit a top-level `static FOO: T = ...;` item.
+    ///
+    /// As with [`Self::visit_item_const`], this only exists so that
+    /// `#[mutants::skip]` on the item suppresses mutants inside the
+    /// initializer expression.
+    fn visit_item_static(&mut self, i: &'ast syn::ItemStatic) {
+        let _span = trace_span!(
+            "static",
+            line = i.static_token.span.start().line,
+            name = i.ident.to_pretty_string()
+        )
+        .entered();
+        if attrs_excluded(&i.attrs) {
+            trace!("static excluded by attrs");
+            return;
+        }
+        syn::visit::visit_item_static(self, i);
+    }
+
+    /// Visit an associated `const FOO: T = ...;` inside an `impl` block.
+    fn visit_impl_item_const(&mut self, i: &'ast syn::ImplItemConst) {
+        let _span = trace_span!(
+            "const",
+            line = i.const_token.span.start().line,
+            name = i.ident.to_pretty_string()
+        )
+        .entered();
+        if attrs_excluded(&i.attrs) {
+            trace!("associated const excluded by attrs");
+            return;
+        }
+        syn::visit::visit_impl_item_const(self, i);
+    }
+
+    /// Visit an associated `const FOO: T [= ...];` inside a `trait` block.
+    ///
+    /// Only the default-value expression (if present) contains anything that
+    /// can be mutated; this method gates that descent on `#[mutants::skip]`.
+    fn visit_trait_item_const(&mut self, i: &'ast syn::TraitItemConst) {
+        let _span = trace_span!(
+            "const",
+            line = i.const_token.span.start().line,
+            name = i.ident.to_pretty_string()
+        )
+        .entered();
+        if attrs_excluded(&i.attrs) {
+            trace!("trait associated const excluded by attrs");
+            return;
+        }
+        syn::visit::visit_trait_item_const(self, i);
+    }
+
     /// Visit `impl Foo { ...}` or `impl Debug for Foo { ... }`.
     fn visit_item_impl(&mut self, i: &'ast syn::ItemImpl) {
         if attrs_excluded(&i.attrs) {
@@ -991,7 +1062,11 @@ mod test {
     mod skip_attr_expr_unary;
     mod skip_attr_file;
     mod skip_attr_impl;
+    mod skip_attr_impl_item_const;
+    mod skip_attr_item_const;
+    mod skip_attr_item_static;
     mod skip_attr_trait;
+    mod skip_attr_trait_item_const;
 
     #[test]
     fn path_ends_with() {

--- a/src/visit/test/skip_attr_impl_item_const.rs
+++ b/src/visit/test/skip_attr_impl_item_const.rs
@@ -1,0 +1,40 @@
+//! Tests that `#[mutants::skip]` on an associated `const` inside an `impl`
+//! block suppresses mutants generated from inside its initializer expression.
+
+use indoc::indoc;
+use test_log::test;
+
+use crate::Options;
+use crate::mutant::Mutant;
+use crate::visit::mutate_source_str;
+
+#[test]
+fn skip_attr_on_impl_associated_const_suppresses_initializer_mutants() {
+    // Different operators on each associated const so the resulting mutants
+    // can be attributed unambiguously to their source item via
+    // `original_text()`, independently of line numbers or whitespace.
+    let mutants = mutate_source_str(
+        indoc! {r#"
+            pub struct S;
+
+            impl S {
+                #[mutants::skip]
+                pub const SKIPPED_FLAGS: u32 = 0b0001 ^ 0b0010;
+
+                pub const OTHER_FLAGS: u32 = 0b0100 | 0b1000;
+            }
+        "#},
+        &Options::default(),
+    )
+    .unwrap();
+    let originals: Vec<String> = mutants.iter().map(Mutant::original_text).collect();
+
+    assert!(
+        !originals.iter().any(|o| o == "^"),
+        "operators inside a skipped associated const should produce no mutants: {mutants:?}"
+    );
+    assert!(
+        originals.iter().any(|o| o == "|"),
+        "sibling unskipped associated const should still produce mutants: {mutants:?}"
+    );
+}

--- a/src/visit/test/skip_attr_item_const.rs
+++ b/src/visit/test/skip_attr_item_const.rs
@@ -1,0 +1,60 @@
+//! Tests that `#[mutants::skip]` on a top-level `const` item suppresses
+//! mutants generated from inside its initializer expression.
+
+use indoc::indoc;
+use test_log::test;
+
+use crate::Options;
+use crate::mutant::Mutant;
+use crate::visit::mutate_source_str;
+
+#[test]
+fn skip_attr_on_item_const_suppresses_initializer_mutants() {
+    // Different operators on each const so the resulting mutants can be
+    // attributed unambiguously to their source item via `original_text()`,
+    // independently of line numbers or whitespace.
+    let mutants = mutate_source_str(
+        indoc! {r#"
+            #[mutants::skip]
+            pub const SKIPPED_FLAGS: u32 = 0b0001 ^ 0b0010;
+
+            pub const OTHER_FLAGS: u32 = 0b0100 | 0b1000;
+        "#},
+        &Options::default(),
+    )
+    .unwrap();
+    let originals: Vec<String> = mutants.iter().map(Mutant::original_text).collect();
+
+    assert!(
+        !originals.iter().any(|o| o == "^"),
+        "operators inside a skipped const initializer should produce no mutants: {mutants:?}"
+    );
+    assert!(
+        originals.iter().any(|o| o == "|"),
+        "sibling unskipped const should still produce mutants: {mutants:?}"
+    );
+}
+
+#[test]
+fn cfg_attr_mutants_skip_on_item_const_suppresses_initializer_mutants() {
+    let mutants = mutate_source_str(
+        indoc! {r#"
+            #[cfg_attr(test, mutants::skip)]
+            pub const SKIPPED_FLAGS: u32 = 0b0001 ^ 0b0010;
+
+            pub const OTHER_FLAGS: u32 = 0b0100 | 0b1000;
+        "#},
+        &Options::default(),
+    )
+    .unwrap();
+    let originals: Vec<String> = mutants.iter().map(Mutant::original_text).collect();
+
+    assert!(
+        !originals.iter().any(|o| o == "^"),
+        "operators inside a const skipped via cfg_attr should produce no mutants: {mutants:?}"
+    );
+    assert!(
+        originals.iter().any(|o| o == "|"),
+        "sibling unskipped const should still produce mutants: {mutants:?}"
+    );
+}

--- a/src/visit/test/skip_attr_item_static.rs
+++ b/src/visit/test/skip_attr_item_static.rs
@@ -1,0 +1,36 @@
+//! Tests that `#[mutants::skip]` on a top-level `static` item suppresses
+//! mutants generated from inside its initializer expression.
+
+use indoc::indoc;
+use test_log::test;
+
+use crate::Options;
+use crate::mutant::Mutant;
+use crate::visit::mutate_source_str;
+
+#[test]
+fn skip_attr_on_item_static_suppresses_initializer_mutants() {
+    // Different operators on each static so the resulting mutants can be
+    // attributed unambiguously to their source item via `original_text()`,
+    // independently of line numbers or whitespace.
+    let mutants = mutate_source_str(
+        indoc! {r#"
+            #[mutants::skip]
+            pub static SKIPPED_FLAGS: u32 = 0b0001 ^ 0b0010;
+
+            pub static OTHER_FLAGS: u32 = 0b0100 | 0b1000;
+        "#},
+        &Options::default(),
+    )
+    .unwrap();
+    let originals: Vec<String> = mutants.iter().map(Mutant::original_text).collect();
+
+    assert!(
+        !originals.iter().any(|o| o == "^"),
+        "operators inside a skipped static initializer should produce no mutants: {mutants:?}"
+    );
+    assert!(
+        originals.iter().any(|o| o == "|"),
+        "sibling unskipped static should still produce mutants: {mutants:?}"
+    );
+}

--- a/src/visit/test/skip_attr_trait_item_const.rs
+++ b/src/visit/test/skip_attr_trait_item_const.rs
@@ -1,0 +1,39 @@
+//! Tests that `#[mutants::skip]` on an associated `const` inside a `trait`
+//! declaration suppresses mutants generated from its default-value
+//! expression.
+
+use indoc::indoc;
+use test_log::test;
+
+use crate::Options;
+use crate::mutant::Mutant;
+use crate::visit::mutate_source_str;
+
+#[test]
+fn skip_attr_on_trait_associated_const_default_suppresses_initializer_mutants() {
+    // Different operators on each associated const so the resulting mutants
+    // can be attributed unambiguously to their source item via
+    // `original_text()`, independently of line numbers or whitespace.
+    let mutants = mutate_source_str(
+        indoc! {r#"
+            pub trait Flags {
+                #[mutants::skip]
+                const SKIPPED_FLAGS: u32 = 0b0001 ^ 0b0010;
+
+                const OTHER_FLAGS: u32 = 0b0100 | 0b1000;
+            }
+        "#},
+        &Options::default(),
+    )
+    .unwrap();
+    let originals: Vec<String> = mutants.iter().map(Mutant::original_text).collect();
+
+    assert!(
+        !originals.iter().any(|o| o == "^"),
+        "operators inside a skipped trait associated const default should produce no mutants: {mutants:?}"
+    );
+    assert!(
+        originals.iter().any(|o| o == "|"),
+        "sibling unskipped trait associated const default should still produce mutants: {mutants:?}"
+    );
+}


### PR DESCRIPTION
Fixes #508.

### Problem

`#[mutants::skip]` (and `#[cfg_attr(..., mutants::skip)]`) placed on a `const` or `static` item was silently ignored. The `DiscoveryVisitor` in `src/visit.rs` had no `visit_item_const` / `visit_item_static` / `visit_impl_item_const` / `visit_trait_item_const`, so `syn`'s default visitor walked straight into the initializer expression and produced the usual operator mutants without consulting the item's attributes.

Reproduced before the fix:

```
src/lib.rs:1:31: replace | with &     # plain const
src/lib.rs:1:31: replace | with ^
src/lib.rs:4:39: replace | with &     # const with #[mutants::skip] - still mutated
src/lib.rs:4:39: replace | with ^
```

### Fix

Added four visitor methods to `DiscoveryVisitor` that bail out via `attrs_excluded(&i.attrs)` when the item carries a skip attribute, and otherwise delegate to the default `syn::visit::visit_*` recursion. Behavior for unskipped consts/statics is unchanged.

The attribute is now honoured on:

- Top-level `const FOO: T = ...;`
- Top-level `static FOO: T = ...;`
- Associated `const` inside `impl` blocks
- Associated `const` defaults inside `trait` blocks

Both `#[mutants::skip]` and `#[cfg_attr(..., mutants::skip)]` work, via the existing `attrs_excluded` helper.

### Tests

Five new tests under `src/visit/test/` following the existing `skip_attr_impl.rs` pattern:

- `skip_attr_item_const.rs` — covers `#[mutants::skip]` and `#[cfg_attr(test, mutants::skip)]` on a top-level `const`
- `skip_attr_item_static.rs` — covers `static`
- `skip_attr_impl_item_const.rs` — covers associated `const` in `impl`
- `skip_attr_trait_item_const.rs` — covers associated `const` default in `trait`

Each test puts a distinct operator on the skipped item (`^`) and on the unskipped sibling (`|`), then asserts on `Mutant::original_text()` rather than line numbers, so reformatting the indoc block cannot turn the assertions into silent passes.

### Documentation

- `book/src/attrs.md`: added a Scope bullet for `const` / `static` items.
- `NEWS.md`: added an Unreleased entry describing the fix.

### Out of scope

Generating fresh "replace value" mutants for const initializers (per @kpreid's follow-up on the issue) would need a new mutation genre and is a separate, larger feature.

### Validation

- `cargo fmt --check` passes
- `cargo clippy --all-targets --all-features -- -D warnings` passes
- `cargo nextest run --all-features --no-fail-fast`: 401/402 pass (the one failure, `symlink_in_source_tree_is_copied`, is a pre-existing Windows symlink-privilege issue unrelated to this change)
- End-to-end repro confirms each item kind now honors both `#[mutants::skip]` and `#[cfg_attr(..., mutants::skip)]` while unskipped items continue to produce mutants as before.
