### PR TITLE
feat: add --incremental alias for --iterate

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- New: `--incremental` is accepted as an alias for `--iterate`.
 - New: `#[mutants::exclude_re("pattern")]` attribute to exclude specific mutations by regex, without disabling all mutations on the function. The attribute can be placed on functions, `impl` blocks, `trait` blocks, modules, files, and on expressions that can carry an attribute (such as `match`, struct literals, call expressions, method calls, and unary expressions). Multiple patterns can be applied. Also supported within `cfg_attr`. Requires the [mutants](https://crates.io/crates/mutants) crate version `0.0.5` or later.
 - Fixed: `#[mutants::skip]` (and `#[cfg_attr(..., mutants::skip)]`) is now honoured when placed on `const` and `static` items, including associated constants in `impl` and `trait` blocks. Previously the attribute was silently ignored on these items and operator mutants inside the initializer expression were still generated ([#508](https://github.com/sourcefrog/cargo-mutants/issues/508)).
 

--- a/book/src/iterate.md
+++ b/book/src/iterate.md
@@ -10,7 +10,7 @@ When you're working to improve test coverage in a tree, you might use a process 
 
 4. Repeat until everything is caught.
 
-You can speed up this process by using the `--iterate` option. This tells cargo-mutants to skip mutants that were either caught or unviable in a previous run, and to accumulate the results.
+You can speed up this process by using the `--iterate` option (also available as `--incremental`). This tells cargo-mutants to skip mutants that were either caught or unviable in a previous run, and to accumulate the results.
 
 You can run repeatedly with `--iterate`, adding tests each time, until all the missed mutants are caught (or skipped.)
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -365,7 +365,7 @@ pub struct Args {
     in_diff: Option<Utf8PathBuf>,
 
     /// Skip mutants that were caught in previous runs.
-    #[arg(long, help_heading = "Filters")]
+    #[arg(long, visible_alias = "incremental", help_heading = "Filters")]
     iterate: bool,
 
     /// Only test mutants from these packages.
@@ -669,6 +669,12 @@ mod test {
         let args = super::Args::try_parse_from(["mutants", "--config=foo.toml", "--no-config"]);
         assert!(args.is_err(), "Expected error due to conflicting options");
         println!("Error message: {}", args.unwrap_err());
+    }
+
+    #[test]
+    fn incremental_alias_enables_iterate() {
+        let args = super::Args::try_parse_from(["mutants", "--incremental"]).unwrap();
+        assert!(args.iterate);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- accept visible `--incremental` as an alias for the existing `--iterate` flag
- keep a single internal state field and add a parser regression test
- document the alias in the user guide and `NEWS.md`

Closes #621.

## Testing

- `cargo test incremental_alias_enables_iterate --all-features` — 1 passed
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `git diff --check`

Tooling disclosure: this change was prepared with OpenAI Codex and validated with the commands above.
