### PR TITLE
Replace unmaintained `fs2` with `fs4`, enabling illumos support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ dependencies = [
  "fastrand",
  "filetime",
  "flickzeug",
- "fs2",
+ "fs4",
  "globset",
  "ignore",
  "indoc",
@@ -507,14 +507,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "fs2"
-version = "0.4.0"
+name = "fs4"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237b7991317b8d94391c0a4813b1f74fd81c11352440cd598d2b763ed288bfc1"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
 dependencies = [
- "kernel32-sys",
- "libc",
- "winapi 0.2.8",
+ "rustix 1.1.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ ctrlc = { version = "3.4", features = ["termination"] }
 fastrand = "2"
 filetime = "0.2.27"
 flickzeug = "0.4.5"
-fs2 = "0.4"
+fs4 = { version = "0.13", default-features = false, features = ["sync"] }
 globset = "0.4.16"
 ignore = "0.4.23"
 indoc = "2.0.0"

--- a/src/output.rs
+++ b/src/output.rs
@@ -10,7 +10,7 @@ use std::thread::sleep;
 use std::time::Duration;
 
 use camino::{Utf8Path, Utf8PathBuf};
-use fs2::FileExt;
+use fs4::fs_std::FileExt;
 use jiff::Timestamp;
 use path_slash::PathExt;
 use serde::Serialize;
@@ -61,12 +61,12 @@ impl LockFile {
             .open(&lock_path)
             .context("open or create lock.json in existing directory")?;
         let mut first = true;
-        while let Err(err) = lock_file.try_lock_exclusive() {
+        while !lock_file
+            .try_lock_exclusive()
+            .context("try to lock lock.json")?
+        {
             if first {
-                info!(
-                    "Waiting for lock on {} ...: {err}",
-                    lock_path.to_slash_lossy()
-                );
+                info!("Waiting for lock on {} ...", lock_path.to_slash_lossy());
                 first = false;
             }
             check_interrupted()?;


### PR DESCRIPTION
`fs2` v0.4 has no `cfg` arm for `target_os = "illumos"` (the target split out of `"solaris"` some time after `fs2`'s last release), so `cargo-mutants` does not build there. `fs4` is the maintained fork of `fs2` with the same flock-based locking and support for current targets (including this one); its sync feature alone suffices for the uses in `cargo-mutants`.

There is one interface difference between `fs2` and `fs4` worth calling out explicitly (it is remediated in this patch): `fs4`'s `try_lock_exclusive` returns `Ok(false)` for a held lock instead of `Err(EWOULDBLOCK)`, so the wait loop now distinguishes contention (keep polling) from real errors (propagate with context) rather than retrying forever on any error. I believe this is a strictly beneficial change, but it is a behavioral change, so I wanted to flag it.

This patch also incidentally allows dropping the old `kernel32-sys` and `winapi` v0.2 transitive dependencies that `fs2` previously pulled in on Windows.